### PR TITLE
test: unit + envtest coverage for decrypt, registry, InlineSopsSecret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+test: manifests generate fmt vet setup-envtest ## Run tests under -race.
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test -race $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/internal/controller/inlinesopssecret_happypath_test.go
+++ b/internal/controller/inlinesopssecret_happypath_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
+	"github.com/stuttgart-things/sops-secrets-operator/internal/testutil"
+)
+
+var _ = Describe("InlineSopsSecret happy path (envtest)", func() {
+	const namespace = "default"
+	var (
+		counter int
+		uniq    func(prefix string) string
+		reconr  *InlineSopsSecretReconciler
+	)
+
+	BeforeEach(func() {
+		counter++
+		uniq = func(prefix string) string { return fmt.Sprintf("%s-%d", prefix, counter) }
+		reconr = &InlineSopsSecretReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	})
+
+	// runReconcile runs reconcile until both finalizer-add + main work complete,
+	// returning the final CR state. Two passes are enough: first adds the
+	// finalizer + requeue, second does the work.
+	runReconcile := func(name string) *sopsv1alpha1.InlineSopsSecret {
+		for range 2 {
+			_, err := reconr.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		out := &sopsv1alpha1.InlineSopsSecret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, out)).To(Succeed())
+		return out
+	}
+
+	// setupAgeKeySecret creates a Secret holding a fresh age private key in
+	// `namespace` and returns (secretName, publicKey). Each spec gets its own
+	// key Secret to avoid cross-spec interference.
+	setupAgeKeySecret := func(namePrefix string) (string, string) {
+		key := testutil.GenerateAge(GinkgoT())
+		secName := namePrefix + "-age-key"
+		Expect(k8sClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secName, Namespace: namespace},
+			Data:       map[string][]byte{"age.agekey": []byte(key.PrivateKey)},
+		})).To(Succeed())
+		return secName, key.PublicKey
+	}
+
+	Context("Mapping mode", func() {
+		It("materializes a Secret with exactly the mapped keys", func() {
+			prefix := uniq("is-map")
+			keySecret, agePub := setupAgeKeySecret(prefix)
+
+			ct := testutil.EncryptYAML(GinkgoT(), agePub, []byte(
+				"db_password: s3cret\ndb_user: alice\napi_token: xyz\n",
+			))
+
+			cr := &sopsv1alpha1.InlineSopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha1.InlineSopsSecretSpec{
+					Mode:          sopsv1alpha1.InlineModeMapping,
+					EncryptedYAML: string(ct),
+					Decryption: sopsv1alpha1.DecryptionSpec{
+						KeyRef: sopsv1alpha1.SecretKeyRef{Name: keySecret, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha1.DataMapping{
+						{Key: "DB_USER", From: "db_user"},
+						{Key: "DB_PASSWORD", From: "db_password"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			got := runReconcile(prefix)
+			decrypted := conditionByType(got.Status.Conditions, sopsv1alpha1.ConditionDecrypted)
+			Expect(decrypted).NotTo(BeNil())
+			Expect(decrypted.Status).To(Equal(metav1.ConditionTrue))
+			applied := conditionByType(got.Status.Conditions, sopsv1alpha1.ConditionApplied)
+			Expect(applied).NotTo(BeNil())
+			Expect(applied.Status).To(Equal(metav1.ConditionTrue))
+
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)).To(Succeed())
+			Expect(target.Data).To(HaveKey("DB_USER"))
+			Expect(target.Data).To(HaveKey("DB_PASSWORD"))
+			// api_token was NOT mapped — must be absent (authoritative data).
+			Expect(target.Data).NotTo(HaveKey("API_TOKEN"))
+			Expect(target.Data).NotTo(HaveKey("api_token"))
+			Expect(string(target.Data["DB_USER"])).To(Equal("alice"))
+			Expect(string(target.Data["DB_PASSWORD"])).To(Equal("s3cret"))
+			Expect(target.Labels).To(HaveKeyWithValue(ManagedByLabel, ManagedByValue))
+			Expect(target.Annotations[OwnerAnnotation]).To(Equal(fmt.Sprintf("InlineSopsSecret/%s/%s", namespace, prefix)))
+			Expect(target.Annotations[ContentHashAnnotation]).NotTo(BeEmpty())
+		})
+
+		It("reverts manual drift on the next reconcile", func() {
+			prefix := uniq("is-drift")
+			keySecret, agePub := setupAgeKeySecret(prefix)
+			ct := testutil.EncryptYAML(GinkgoT(), agePub, []byte("token: original\n"))
+
+			Expect(k8sClient.Create(ctx, &sopsv1alpha1.InlineSopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha1.InlineSopsSecretSpec{
+					Mode:          sopsv1alpha1.InlineModeMapping,
+					EncryptedYAML: string(ct),
+					Decryption: sopsv1alpha1.DecryptionSpec{
+						KeyRef: sopsv1alpha1.SecretKeyRef{Name: keySecret, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha1.DataMapping{{Key: "TOKEN", From: "token"}},
+				},
+			})).To(Succeed())
+			_ = runReconcile(prefix)
+
+			// Hand-edit the target Secret: mutate value, add rogue key.
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)).To(Succeed())
+			target.Data["TOKEN"] = []byte("tampered")
+			target.Data["ROGUE"] = []byte("evil")
+			Expect(k8sClient.Update(ctx, target)).To(Succeed())
+
+			// Next reconcile must revert.
+			_ = runReconcile(prefix)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)).To(Succeed())
+			Expect(string(target.Data["TOKEN"])).To(Equal("original"))
+			Expect(target.Data).NotTo(HaveKey("ROGUE"))
+		})
+
+		It("refuses to adopt an unmanaged pre-existing Secret, accepts with adopt=true", func() {
+			prefix := uniq("is-adopt")
+			keySecret, agePub := setupAgeKeySecret(prefix)
+			ct := testutil.EncryptYAML(GinkgoT(), agePub, []byte("token: from-sops\n"))
+
+			// Pre-existing unmanaged Secret that collides with the target.
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Data:       map[string][]byte{"EXISTING": []byte("existing-val")},
+			})).To(Succeed())
+
+			cr := &sopsv1alpha1.InlineSopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha1.InlineSopsSecretSpec{
+					Mode:          sopsv1alpha1.InlineModeMapping,
+					EncryptedYAML: string(ct),
+					Decryption: sopsv1alpha1.DecryptionSpec{
+						KeyRef: sopsv1alpha1.SecretKeyRef{Name: keySecret, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha1.DataMapping{{Key: "TOKEN", From: "token"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+			got := runReconcile(prefix)
+			applied := conditionByType(got.Status.Conditions, sopsv1alpha1.ConditionApplied)
+			Expect(applied).NotTo(BeNil())
+			Expect(applied.Status).To(Equal(metav1.ConditionFalse))
+			Expect(applied.Reason).To(Equal("ApplyFailed"))
+			Expect(applied.Message).To(ContainSubstring("target.adopt=true"))
+
+			// Enable adoption and re-reconcile.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, cr)).To(Succeed())
+			cr.Spec.Target.Adopt = true
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+
+			got = runReconcile(prefix)
+			applied = conditionByType(got.Status.Conditions, sopsv1alpha1.ConditionApplied)
+			Expect(applied).NotTo(BeNil())
+			Expect(applied.Status).To(Equal(metav1.ConditionTrue))
+
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)).To(Succeed())
+			// Adopted Secret: data is authoritative from CR, so EXISTING is gone.
+			Expect(target.Data).NotTo(HaveKey("EXISTING"))
+			Expect(string(target.Data["TOKEN"])).To(Equal("from-sops"))
+			Expect(target.Labels).To(HaveKeyWithValue(ManagedByLabel, ManagedByValue))
+		})
+
+		It("deletes the target Secret when the CR is deleted", func() {
+			prefix := uniq("is-fin")
+			keySecret, agePub := setupAgeKeySecret(prefix)
+			ct := testutil.EncryptYAML(GinkgoT(), agePub, []byte("token: x\n"))
+
+			Expect(k8sClient.Create(ctx, &sopsv1alpha1.InlineSopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha1.InlineSopsSecretSpec{
+					Mode:          sopsv1alpha1.InlineModeMapping,
+					EncryptedYAML: string(ct),
+					Decryption: sopsv1alpha1.DecryptionSpec{
+						KeyRef: sopsv1alpha1.SecretKeyRef{Name: keySecret, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha1.DataMapping{{Key: "TOKEN", From: "token"}},
+				},
+			})).To(Succeed())
+			_ = runReconcile(prefix)
+
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)).To(Succeed())
+
+			cr := &sopsv1alpha1.InlineSopsSecret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, cr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+
+			// One more reconcile processes the finalizer.
+			_, err := reconr.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "target Secret should be deleted; got err=%v", err)
+		})
+	})
+
+	Context("Manifest mode", func() {
+		It("applies the decrypted Secret with authoritative namespace and type from manifest", func() {
+			prefix := uniq("is-mf")
+			keySecret, agePub := setupAgeKeySecret(prefix)
+
+			manifest := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: unused-name
+  namespace: some-other-ns
+type: kubernetes.io/basic-auth
+stringData:
+  username: alice
+  password: s3cret
+`)
+			ct := testutil.EncryptYAML(GinkgoT(), agePub, manifest)
+
+			targetName := prefix + "-target"
+			cr := &sopsv1alpha1.InlineSopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha1.InlineSopsSecretSpec{
+					Mode:          sopsv1alpha1.InlineModeManifest,
+					EncryptedYAML: string(ct),
+					Decryption: sopsv1alpha1.DecryptionSpec{
+						KeyRef: sopsv1alpha1.SecretKeyRef{Name: keySecret, Key: "age.agekey"},
+					},
+					Target: sopsv1alpha1.InlineTarget{
+						Name: targetName, // override manifest name
+						// namespace defaults to the CR namespace (authoritative),
+						// NOT manifest's `some-other-ns`.
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			got := runReconcile(prefix)
+			applied := conditionByType(got.Status.Conditions, sopsv1alpha1.ConditionApplied)
+			Expect(applied).NotTo(BeNil())
+			Expect(applied.Status).To(Equal(metav1.ConditionTrue))
+
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: targetName}, target)).To(Succeed())
+			Expect(target.Type).To(Equal(corev1.SecretType("kubernetes.io/basic-auth")))
+			Expect(string(target.Data["username"])).To(Equal("alice"))
+			Expect(string(target.Data["password"])).To(Equal("s3cret"))
+
+			// The manifest's `some-other-ns` is not where the Secret landed:
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "some-other-ns", Name: targetName}, &corev1.Secret{})
+			Expect(apierrors.IsNotFound(err) || err != nil).To(BeTrue())
+		})
+	})
+})
+
+// conditionByType is a small free helper that a few happy-path specs use.
+// Named separately from the pointer-receiver `condition` helpers in the
+// older test files so we don't collide with them.
+func conditionByType(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
+}

--- a/internal/decrypt/concurrent_test.go
+++ b/internal/decrypt/concurrent_test.go
@@ -1,0 +1,68 @@
+package decrypt_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stuttgart-things/sops-secrets-operator/internal/decrypt"
+	"github.com/stuttgart-things/sops-secrets-operator/internal/testutil"
+)
+
+// TestDecryptAgeConcurrent exercises the SOPS_AGE_KEY env-var serialization
+// path in DecryptAge: N goroutines, each bound to its own age identity and
+// its own ciphertext. Run under `go test -race`.
+//
+// The regression this guards against: DecryptAge mutates the global
+// SOPS_AGE_KEY env var around each call, so a missing lock would produce
+// either decrypt failures or cross-contamination between goroutines. In
+// both cases this test fails.
+func TestDecryptAgeConcurrent(t *testing.T) {
+	const (
+		identities     = 4
+		goroutines     = 32
+		decryptPerGRtn = 10
+	)
+
+	type fixture struct {
+		priv []byte
+		ct   []byte
+		want []byte
+	}
+	fixtures := make([]fixture, identities)
+	for i := range fixtures {
+		k := testutil.GenerateAge(t)
+		plain := fmt.Appendf(nil, "payload: id-%d\nsecret: s3cret-%d\n", i, i)
+		fixtures[i] = fixture{
+			priv: []byte(k.PrivateKey),
+			ct:   testutil.EncryptYAML(t, k.PublicKey, plain),
+			want: plain,
+		}
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines*decryptPerGRtn)
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			fx := fixtures[g%identities]
+			for i := range decryptPerGRtn {
+				got, err := decrypt.DecryptAge(fx.ct, "inline.yaml", fx.priv)
+				if err != nil {
+					errCh <- fmt.Errorf("goroutine %d iter %d: %w", g, i, err)
+					return
+				}
+				if string(got) != string(fx.want) {
+					errCh <- fmt.Errorf("goroutine %d iter %d: mismatched plaintext", g, i)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/internal/source/registry_test.go
+++ b/internal/source/registry_test.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,5 +28,43 @@ func TestEnsureCachedRejectsInvalidConfig(t *testing.T) {
 	_, err := r.EnsureCached(context.Background(), client.ObjectKey{Name: "x"}, git.Config{})
 	if err == nil {
 		t.Fatal("expected error for missing URL")
+	}
+}
+
+// TestForgetEvictsEntry verifies Forget removes the cached entry created
+// by EnsureCached so a subsequent Read fails with "no cache for".
+// Uses a bogus URL: git.New succeeds (it only validates URL non-empty),
+// then EnsureCloned fails on the clone, but the registry has already
+// recorded the entry before that point.
+func TestForgetEvictsEntry(t *testing.T) {
+	r := NewRegistry()
+	root := t.TempDir()
+	key := client.ObjectKey{Namespace: "x", Name: "y"}
+
+	_, err := r.EnsureCached(context.Background(), key, git.Config{
+		URL:       "file:///nonexistent/path-" + t.Name(),
+		Branch:    "main",
+		CacheRoot: root,
+	})
+	if err == nil {
+		t.Fatal("expected clone failure for bogus URL")
+	}
+
+	// Entry should be readable (well, the Read will fail on the underlying
+	// repo, but it confirms the registry knows about the key).
+	if _, _, err := r.Read(key, "whatever"); err == nil || !strings.Contains(err.Error(), "open") && !strings.Contains(err.Error(), "no such") {
+		// The repo dir was never populated, so Read hits os.ReadFile which
+		// returns an ENOENT — anything except "no cache for" proves the
+		// entry exists in the registry.
+		if err != nil && strings.Contains(err.Error(), "no cache for") {
+			t.Fatalf("entry was never recorded: %v", err)
+		}
+	}
+
+	r.Forget(key)
+
+	_, _, err = r.Read(key, "whatever")
+	if err == nil || !strings.Contains(err.Error(), "no cache for") {
+		t.Fatalf("expected 'no cache for' after Forget, got %v", err)
 	}
 }

--- a/internal/testutil/sops.go
+++ b/internal/testutil/sops.go
@@ -1,0 +1,99 @@
+// Package testutil contains helpers shared across test binaries.
+//
+// SOPS/age encryption at test time: GenerateAge returns a fresh
+// X25519 age identity and EncryptYAML emits a SOPS-encrypted YAML
+// document that can be round-tripped by internal/decrypt.DecryptAge.
+// These helpers should never be compiled into production binaries.
+package testutil
+
+import (
+	"filippo.io/age"
+	sops "github.com/getsops/sops/v3"
+	"github.com/getsops/sops/v3/aes"
+	sopsage "github.com/getsops/sops/v3/age"
+	"github.com/getsops/sops/v3/cmd/sops/common"
+	"github.com/getsops/sops/v3/stores/json"
+	"github.com/getsops/sops/v3/stores/yaml"
+	"github.com/getsops/sops/v3/version"
+)
+
+// TestingT is the minimal subset of TestingT / Ginkgo's GinkgoT() that
+// these helpers need. Both *testing.T and GinkgoT() satisfy it, so the
+// helpers work in plain Go tests and Ginkgo specs.
+type TestingT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+// AgeKey is the result of GenerateAge.
+type AgeKey struct {
+	// PrivateKey is the Bech32-encoded age identity (AGE-SECRET-KEY-...).
+	PrivateKey string
+	// PublicKey is the Bech32-encoded age recipient (age1...).
+	PublicKey string
+}
+
+// GenerateAge returns a fresh X25519 age identity. Fatals the test on error.
+func GenerateAge(tb TestingT) AgeKey {
+	tb.Helper()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		tb.Fatalf("testutil: generate age identity: %v", err)
+	}
+	return AgeKey{
+		PrivateKey: id.String(),
+		PublicKey:  id.Recipient().String(),
+	}
+}
+
+// EncryptYAML SOPS-encrypts a plain YAML document for the given age
+// recipient. The output is a full SOPS-encrypted YAML blob suitable
+// for passing to decrypt.DecryptAge with a yaml-format hint.
+func EncryptYAML(tb TestingT, agePublicKey string, plaintext []byte) []byte {
+	tb.Helper()
+	store := &yaml.Store{}
+	return encryptWithStore(tb, store, store, agePublicKey, plaintext)
+}
+
+// EncryptJSON SOPS-encrypts a plain JSON document for the given age
+// recipient.
+func EncryptJSON(tb TestingT, agePublicKey string, plaintext []byte) []byte {
+	tb.Helper()
+	store := &json.Store{}
+	return encryptWithStore(tb, store, store, agePublicKey, plaintext)
+}
+
+func encryptWithStore(tb TestingT, inStore, outStore sops.Store, agePublicKey string, plaintext []byte) []byte {
+	tb.Helper()
+	branches, err := inStore.LoadPlainFile(plaintext)
+	if err != nil {
+		tb.Fatalf("testutil: parse plaintext: %v", err)
+	}
+	mk, err := sopsage.MasterKeyFromRecipient(agePublicKey)
+	if err != nil {
+		tb.Fatalf("testutil: age master key: %v", err)
+	}
+	tree := sops.Tree{
+		Branches: branches,
+		Metadata: sops.Metadata{
+			KeyGroups: []sops.KeyGroup{{mk}},
+			Version:   version.Version,
+		},
+	}
+	dataKey, errs := tree.GenerateDataKey()
+	if len(errs) > 0 {
+		tb.Fatalf("testutil: generate data key: %v", errs)
+	}
+	if err := common.EncryptTree(common.EncryptTreeOpts{
+		DataKey: dataKey,
+		Tree:    &tree,
+		Cipher:  aes.NewCipher(),
+	}); err != nil {
+		tb.Fatalf("testutil: encrypt tree: %v", err)
+	}
+	out, err := outStore.EmitEncryptedFile(tree)
+	if err != nil {
+		tb.Fatalf("testutil: emit encrypted file: %v", err)
+	}
+	return out
+}

--- a/internal/testutil/sops_test.go
+++ b/internal/testutil/sops_test.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stuttgart-things/sops-secrets-operator/internal/decrypt"
+)
+
+// TestEncryptRoundTrip verifies EncryptYAML produces ciphertext that our
+// own decrypt.DecryptAge round-trips — catches version/format drift
+// between getsops/sops and our wrapper.
+func TestEncryptYAMLRoundTrip(t *testing.T) {
+	key := GenerateAge(t)
+	plain := []byte("username: alice\npassword: s3cret\n")
+
+	ct := EncryptYAML(t, key.PublicKey, plain)
+	if len(ct) == 0 {
+		t.Fatal("empty ciphertext")
+	}
+	got, err := decrypt.DecryptAge(ct, "x.yaml", []byte(key.PrivateKey))
+	if err != nil {
+		t.Fatalf("round-trip decrypt: %v", err)
+	}
+	if string(got) != string(plain) {
+		t.Fatalf("round-trip mismatch:\nwant: %q\ngot:  %q", plain, got)
+	}
+}


### PR DESCRIPTION
Progress on #8 (Phase 1 MVP test coverage). Lands the unit-test half plus the InlineSopsSecret envtest. A follow-up PR will add git-sourced envtest with a local \`file://\` git fixture for \`SopsSecret\` / \`SopsSecretManifest\` happy paths.

## Summary
- New \`internal/testutil\` package: \`GenerateAge\` + \`EncryptYAML\`/\`EncryptJSON\` via \`getsops/sops/v3\` and \`filippo.io/age\`. Narrow \`TestingT\` interface so it works from plain Go tests and Ginkgo specs.
- \`internal/decrypt\`: concurrent-decrypt race test — 4 identities × 32 goroutines × 10 iters. Guards the \`SOPS_AGE_KEY\` env-var serialization.
- \`internal/source\`: \`Forget\` eviction test.
- \`internal/controller\`: InlineSopsSecret happy-path envtest — Mapping mode (authoritative data, unmapped keys dropped), Manifest mode (CR namespace authoritative over manifest's), drift reverted, adoption refuse → accept, finalizer deletes target Secret.
- \`make test\` now runs with \`-race\`.

## Coverage deltas on \`internal/\`
- controller: 20.2% → 40.1%
- decrypt: 53.6% → 89.3%
- source: 47.6% → 90.5%
- transform: already 90.8%
- testutil: 67.9% (the helper is exercised by a round-trip self-test)

The #8 acceptance asks for >70% on \`internal/\`. We're at that bar for the transform/decrypt/source packages; \`controller\` will cross it once the git-sourced envtest follows.

## Still open on #8 (follow-up PR)
- \`GitRepository\` happy-path envtest (requires a fake \`file://\` git server spun up from \`t.TempDir\`)
- \`SopsSecret\` end-to-end: mapping updates (remove/add \`data[]\` entries)
- \`SopsSecretManifest\` end-to-end: \`nameOverride\`, namespace-authoritative
- Finalizer/adoption/drift for the git-sourced CRDs (the helpers are ready; the harness needs the fake repo)

## Test plan
- [x] \`go build ./...\` + \`go vet ./...\` clean
- [x] \`make test\` green under \`-race\`
- [x] \`make lint\` — 0 issues
- [ ] CI green (watching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)