### PR TITLE
chore(dev): Taskfile with kcl:sync-crds + kcl:render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 bin/*
 Dockerfile.cross
 
+# go-task cache
+.task/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,44 @@
+version: "3"
+
+# Task runner for ad-hoc developer flows that don't belong in the
+# kubebuilder-scaffolded Makefile. The Makefile still owns the core
+# build / test / lint / manifest-generation targets; tasks here wrap
+# auxiliary workflows like rendering the KCL deployment bundle.
+
+tasks:
+  default:
+    desc: List available tasks.
+    cmds:
+      - task --list
+    silent: true
+
+  kcl:sync-crds:
+    desc: Copy generated CRDs into kcl/crds/ so the KCL bundle stays in sync with config/crd/bases.
+    deps: [_kcl:ensure-manifests]
+    sources:
+      - config/crd/bases/sops.stuttgart-things.com_*.yaml
+    generates:
+      - kcl/crds/sops.stuttgart-things.com_*.yaml
+    cmds:
+      - cp config/crd/bases/sops.stuttgart-things.com_*.yaml kcl/crds/
+
+  kcl:render:
+    desc: Render the KCL deployment bundle to multi-doc YAML at bin/kcl-rendered.yaml.
+    deps: [kcl:sync-crds]
+    preconditions:
+      - sh: command -v kcl
+        msg: "kcl is not installed; see https://kcl-lang.io"
+      - sh: command -v yq
+        msg: "yq is required to split KCL output into multi-doc YAML"
+    cmds:
+      - mkdir -p bin
+      - 'cd kcl && kcl run main.k -Y ../tests/kcl-deploy-profile.yaml | yq eval ''.manifests[] | split_doc'' - > "{{.ROOT_DIR}}/bin/kcl-rendered.yaml"'
+      - echo "--- rendered manifests in bin/kcl-rendered.yaml ---"
+      - 'yq eval ''.apiVersion + "/" + .kind + " " + .metadata.name'' "{{.ROOT_DIR}}/bin/kcl-rendered.yaml"'
+
+  _kcl:ensure-manifests:
+    # Delegate to the Makefile target so CRDs exist before syncing.
+    # Kept internal (leading underscore) since it's an implementation detail.
+    internal: true
+    cmds:
+      - make manifests


### PR DESCRIPTION
Adds a go-task \`Taskfile.yaml\` at the repo root for dev-loop workflows that don't belong in the kubebuilder-scaffolded Makefile. The Makefile keeps owning the core flow (build / test / lint / manifests); ad-hoc tooling goes into Tasks.

## Summary
- \`task kcl:sync-crds\` — copies \`config/crd/bases/sops.*.yaml\` → \`kcl/crds/\` so the KCL bundle doesn't drift from the generated CRDs locally. \`sources\`/\`generates\` entries let Task skip when inputs haven't changed. The release workflow (\`release.yaml\`) already does this at tag time; this is the dev-time mirror.
- \`task kcl:render\` — depends on \`kcl:sync-crds\`, runs \`kcl run main.k -Y tests/kcl-deploy-profile.yaml\`, pipes through \`yq\` to unwrap the \`manifests:\` list into multi-doc YAML at \`bin/kcl-rendered.yaml\`, then prints the kind/name table.
- \`preconditions\` check for \`kcl\` and \`yq\` on PATH with actionable error messages.
- \`.task/\` (local Task cache) added to \`.gitignore\`.

## Smoke check
Local \`task kcl:render\` produces 9 documents:
- 4 CRDs (\`GitRepository\`, \`SopsSecret\`, \`SopsSecretManifest\`, \`InlineSopsSecret\`)
- \`Namespace\`, \`ServiceAccount\`, \`ClusterRole\`, \`ClusterRoleBinding\`, \`Deployment\` — all named \`sops-secrets-operator\`

## Test plan
- [x] \`task --list\` shows both tasks
- [x] \`task kcl:render\` produces valid multi-doc YAML at \`bin/kcl-rendered.yaml\`
- [ ] CI green (watching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)