### PR TITLE
feat: sourceRef dispatch (Stage C of #12) + force-sync annotation (#23)

### DIFF
--- a/api/v1alpha1/gitrepository_conversion.go
+++ b/api/v1alpha1/gitrepository_conversion.go
@@ -34,10 +34,11 @@ func (src *GitRepository) ConvertTo(dstRaw conversion.Hub) error {
 		}
 	}
 	dst.Status = v1alpha2.GitRepositoryStatus{
-		LastSyncedCommit:   src.Status.LastSyncedCommit,
-		CacheReady:         src.Status.CacheReady,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastSyncedCommit:            src.Status.LastSyncedCommit,
+		CacheReady:                  src.Status.CacheReady,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }
@@ -60,10 +61,11 @@ func (dst *GitRepository) ConvertFrom(srcRaw conversion.Hub) error {
 		}
 	}
 	dst.Status = GitRepositoryStatus{
-		LastSyncedCommit:   src.Status.LastSyncedCommit,
-		CacheReady:         src.Status.CacheReady,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastSyncedCommit:            src.Status.LastSyncedCommit,
+		CacheReady:                  src.Status.CacheReady,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }

--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -77,6 +77,12 @@ type GitRepositoryStatus struct {
 	// +optional
 	CacheReady bool `json:"cacheReady,omitempty"`
 
+	// LastProcessedReconcileToken records the last value of the
+	// sops.stuttgart-things.com/reconcile-requested annotation that the
+	// reconciler honored (cache eviction + forced fetch).
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// ObservedGeneration reflects the generation most recently reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/api/v1alpha1/inlinesopssecret_conversion.go
+++ b/api/v1alpha1/inlinesopssecret_conversion.go
@@ -39,9 +39,10 @@ func (src *InlineSopsSecret) ConvertTo(dstRaw conversion.Hub) error {
 		Data: convertDataMappingsTo(src.Spec.Data),
 	}
 	dst.Status = v1alpha2.InlineSopsSecretStatus{
-		LastAppliedHash:    src.Status.LastAppliedHash,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastAppliedHash:             src.Status.LastAppliedHash,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }
@@ -68,9 +69,10 @@ func (dst *InlineSopsSecret) ConvertFrom(srcRaw conversion.Hub) error {
 		Data: convertDataMappingsFrom(src.Spec.Data),
 	}
 	dst.Status = InlineSopsSecretStatus{
-		LastAppliedHash:    src.Status.LastAppliedHash,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastAppliedHash:             src.Status.LastAppliedHash,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }

--- a/api/v1alpha1/inlinesopssecret_types.go
+++ b/api/v1alpha1/inlinesopssecret_types.go
@@ -108,6 +108,12 @@ type InlineSopsSecretStatus struct {
 	// +optional
 	LastAppliedHash string `json:"lastAppliedHash,omitempty"`
 
+	// LastProcessedReconcileToken records the last value of the
+	// sops.stuttgart-things.com/reconcile-requested annotation that the
+	// reconciler honored (forced re-decrypt + re-apply).
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// ObservedGeneration reflects the generation most recently reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/api/v1alpha1/sopssecret_conversion.go
+++ b/api/v1alpha1/sopssecret_conversion.go
@@ -47,10 +47,11 @@ func (src *SopsSecret) ConvertTo(dstRaw conversion.Hub) error {
 		Data: convertDataMappingsTo(src.Spec.Data),
 	}
 	dst.Status = v1alpha2.SopsSecretStatus{
-		LastAppliedHash:    src.Status.LastAppliedHash,
-		LastSyncedCommit:   src.Status.LastSyncedCommit,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastAppliedHash:             src.Status.LastAppliedHash,
+		LastSyncedCommit:            src.Status.LastSyncedCommit,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }
@@ -86,10 +87,11 @@ func (dst *SopsSecret) ConvertFrom(srcRaw conversion.Hub) error {
 		Data: convertDataMappingsFrom(src.Spec.Data),
 	}
 	dst.Status = SopsSecretStatus{
-		LastAppliedHash:    src.Status.LastAppliedHash,
-		LastSyncedCommit:   src.Status.LastSyncedCommit,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastAppliedHash:             src.Status.LastAppliedHash,
+		LastSyncedCommit:            src.Status.LastSyncedCommit,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }

--- a/api/v1alpha1/sopssecret_types.go
+++ b/api/v1alpha1/sopssecret_types.go
@@ -99,6 +99,13 @@ type SopsSecretStatus struct {
 	// +optional
 	LastSyncedCommit string `json:"lastSyncedCommit,omitempty"`
 
+	// LastProcessedReconcileToken records the last value of the
+	// sops.stuttgart-things.com/reconcile-requested annotation that the
+	// reconciler honored. When the annotation is changed, the next
+	// reconcile re-runs the full read/decrypt/apply pipeline.
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// ObservedGeneration reflects the generation most recently reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -117,7 +124,6 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=".spec.source.repositoryRef.name"
 // +kubebuilder:printcolumn:name="Path",type=string,JSONPath=".spec.source.path"
 // +kubebuilder:printcolumn:name="Applied",type=string,JSONPath=".status.conditions[?(@.type==\"Applied\")].status"

--- a/api/v1alpha1/sopssecretmanifest_conversion.go
+++ b/api/v1alpha1/sopssecretmanifest_conversion.go
@@ -43,10 +43,11 @@ func (src *SopsSecretManifest) ConvertTo(dstRaw conversion.Hub) error {
 		},
 	}
 	dst.Status = v1alpha2.SopsSecretManifestStatus{
-		LastAppliedHash:    src.Status.LastAppliedHash,
-		LastSyncedCommit:   src.Status.LastSyncedCommit,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastAppliedHash:             src.Status.LastAppliedHash,
+		LastSyncedCommit:            src.Status.LastSyncedCommit,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }
@@ -79,10 +80,11 @@ func (dst *SopsSecretManifest) ConvertFrom(srcRaw conversion.Hub) error {
 		},
 	}
 	dst.Status = SopsSecretManifestStatus{
-		LastAppliedHash:    src.Status.LastAppliedHash,
-		LastSyncedCommit:   src.Status.LastSyncedCommit,
-		ObservedGeneration: src.Status.ObservedGeneration,
-		Conditions:         src.Status.Conditions,
+		LastAppliedHash:             src.Status.LastAppliedHash,
+		LastSyncedCommit:            src.Status.LastSyncedCommit,
+		LastProcessedReconcileToken: src.Status.LastProcessedReconcileToken,
+		ObservedGeneration:          src.Status.ObservedGeneration,
+		Conditions:                  src.Status.Conditions,
 	}
 	return nil
 }

--- a/api/v1alpha1/sopssecretmanifest_types.go
+++ b/api/v1alpha1/sopssecretmanifest_types.go
@@ -66,6 +66,10 @@ type SopsSecretManifestStatus struct {
 	// +optional
 	LastSyncedCommit string `json:"lastSyncedCommit,omitempty"`
 
+	// LastProcessedReconcileToken mirrors SopsSecret's field.
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// ObservedGeneration reflects the generation most recently reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -78,7 +82,6 @@ type SopsSecretManifestStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=".spec.source.repositoryRef.name"
 // +kubebuilder:printcolumn:name="Path",type=string,JSONPath=".spec.source.path"
 // +kubebuilder:printcolumn:name="Applied",type=string,JSONPath=".status.conditions[?(@.type==\"Applied\")].status"

--- a/api/v1alpha2/gitrepository_types.go
+++ b/api/v1alpha2/gitrepository_types.go
@@ -63,6 +63,9 @@ type GitRepositoryStatus struct {
 	CacheReady bool `json:"cacheReady,omitempty"`
 
 	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// +listType=map

--- a/api/v1alpha2/inlinesopssecret_types.go
+++ b/api/v1alpha2/inlinesopssecret_types.go
@@ -68,6 +68,9 @@ type InlineSopsSecretStatus struct {
 	LastAppliedHash string `json:"lastAppliedHash,omitempty"`
 
 	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// +listType=map

--- a/api/v1alpha2/objectsource_types.go
+++ b/api/v1alpha2/objectsource_types.go
@@ -105,6 +105,12 @@ type ObjectSourceStatus struct {
 	// +optional
 	CacheReady bool `json:"cacheReady,omitempty"`
 
+	// LastProcessedReconcileToken records the last value of the
+	// sops.stuttgart-things.com/reconcile-requested annotation that the
+	// reconciler honored (cache eviction + unconditional refetch).
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 

--- a/api/v1alpha2/sopssecret_types.go
+++ b/api/v1alpha2/sopssecret_types.go
@@ -88,6 +88,13 @@ type SopsSecretStatus struct {
 	// +optional
 	LastSyncedCommit string `json:"lastSyncedCommit,omitempty"`
 
+	// LastProcessedReconcileToken is the value of the
+	// sops.stuttgart-things.com/reconcile-requested annotation that was last
+	// honored by the reconciler. When the live annotation differs, the next
+	// reconcile re-runs the full pipeline regardless of cache state.
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
@@ -105,6 +112,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=".spec.source.sourceRef.name"
 // +kubebuilder:printcolumn:name="Kind",type=string,JSONPath=".spec.source.sourceRef.kind"
 // +kubebuilder:printcolumn:name="Path",type=string,JSONPath=".spec.source.path"

--- a/api/v1alpha2/sopssecretmanifest_types.go
+++ b/api/v1alpha2/sopssecretmanifest_types.go
@@ -51,6 +51,10 @@ type SopsSecretManifestStatus struct {
 	// +optional
 	LastSyncedCommit string `json:"lastSyncedCommit,omitempty"`
 
+	// LastProcessedReconcileToken mirrors SopsSecret's field.
+	// +optional
+	LastProcessedReconcileToken string `json:"lastProcessedReconcileToken,omitempty"`
+
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
@@ -62,6 +66,7 @@ type SopsSecretManifestStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=".spec.source.sourceRef.name"
 // +kubebuilder:printcolumn:name="Kind",type=string,JSONPath=".spec.source.sourceRef.kind"
 // +kubebuilder:printcolumn:name="Path",type=string,JSONPath=".spec.source.path"

--- a/config/crd/bases/sops.stuttgart-things.com_gitrepositories.yaml
+++ b/config/crd/bases/sops.stuttgart-things.com_gitrepositories.yaml
@@ -168,6 +168,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastProcessedReconcileToken:
+                description: |-
+                  LastProcessedReconcileToken records the last value of the
+                  sops.stuttgart-things.com/reconcile-requested annotation that the
+                  reconciler honored (cache eviction + forced fetch).
+                type: string
               lastSyncedCommit:
                 description: LastSyncedCommit is the commit SHA at the last successful
                   reconcile.
@@ -329,6 +335,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastProcessedReconcileToken:
+                type: string
               lastSyncedCommit:
                 type: string
               observedGeneration:

--- a/config/crd/bases/sops.stuttgart-things.com_inlinesopssecrets.yaml
+++ b/config/crd/bases/sops.stuttgart-things.com_inlinesopssecrets.yaml
@@ -226,6 +226,12 @@ spec:
                   LastAppliedHash is the SHA-256 of the most recently applied target
                   Secret.
                 type: string
+              lastProcessedReconcileToken:
+                description: |-
+                  LastProcessedReconcileToken records the last value of the
+                  sops.stuttgart-things.com/reconcile-requested annotation that the
+                  reconciler honored (forced re-decrypt + re-apply).
+                type: string
               observedGeneration:
                 description: ObservedGeneration reflects the generation most recently
                   reconciled.
@@ -411,6 +417,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               lastAppliedHash:
+                type: string
+              lastProcessedReconcileToken:
                 type: string
               observedGeneration:
                 format: int64

--- a/config/crd/bases/sops.stuttgart-things.com_objectsources.yaml
+++ b/config/crd/bases/sops.stuttgart-things.com_objectsources.yaml
@@ -191,6 +191,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastProcessedReconcileToken:
+                description: |-
+                  LastProcessedReconcileToken records the last value of the
+                  sops.stuttgart-things.com/reconcile-requested annotation that the
+                  reconciler honored (cache eviction + unconditional refetch).
+                type: string
               lastSyncedAt:
                 description: LastSyncedAt is the wall-clock time of the last successful
                   reconcile.

--- a/config/crd/bases/sops.stuttgart-things.com_sopssecretmanifests.yaml
+++ b/config/crd/bases/sops.stuttgart-things.com_sopssecretmanifests.yaml
@@ -191,6 +191,9 @@ spec:
                   LastAppliedHash is the SHA-256 of the most recently applied target
                   Secret (type + data/stringData).
                 type: string
+              lastProcessedReconcileToken:
+                description: LastProcessedReconcileToken mirrors SopsSecret's field.
+                type: string
               lastSyncedCommit:
                 description: LastSyncedCommit is the source repository commit at the
                   last apply.
@@ -205,7 +208,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -393,6 +396,9 @@ spec:
                 x-kubernetes-list-type: map
               lastAppliedHash:
                 type: string
+              lastProcessedReconcileToken:
+                description: LastProcessedReconcileToken mirrors SopsSecret's field.
+                type: string
               lastSyncedCommit:
                 type: string
               observedGeneration:
@@ -403,6 +409,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/bases/sops.stuttgart-things.com_sopssecrets.yaml
+++ b/config/crd/bases/sops.stuttgart-things.com_sopssecrets.yaml
@@ -208,6 +208,13 @@ spec:
                   LastAppliedHash is the SHA-256 of the most recently applied target
                   Secret data (deterministic over the key-sorted key/value pairs).
                 type: string
+              lastProcessedReconcileToken:
+                description: |-
+                  LastProcessedReconcileToken records the last value of the
+                  sops.stuttgart-things.com/reconcile-requested annotation that the
+                  reconciler honored. When the annotation is changed, the next
+                  reconcile re-runs the full read/decrypt/apply pipeline.
+                type: string
               lastSyncedCommit:
                 description: LastSyncedCommit is the source repository commit at the
                   last apply.
@@ -222,7 +229,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -426,6 +433,13 @@ spec:
                 x-kubernetes-list-type: map
               lastAppliedHash:
                 type: string
+              lastProcessedReconcileToken:
+                description: |-
+                  LastProcessedReconcileToken is the value of the
+                  sops.stuttgart-things.com/reconcile-requested annotation that was last
+                  honored by the reconciler. When the live annotation differs, the next
+                  reconcile re-runs the full pipeline regardless of cache state.
+                type: string
               lastSyncedCommit:
                 type: string
               observedGeneration:
@@ -436,6 +450,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,11 +10,16 @@ resources:
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
-# patches here are for enabling the conversion webhook for each CRD
+# Conversion-webhook patches: SopsSecret and SopsSecretManifest changed shape
+# between v1alpha1 (RepositoryRef) and v1alpha2 (SourceRef), so they need
+# webhook-strategy conversion. GitRepository / InlineSopsSecret / ObjectSource
+# do not (single-version or isomorphic schemas) and stay on the default
+# strategy ("None").
+- path: patches/webhook_in_sopssecrets.yaml
+- path: patches/webhook_in_sopssecretmanifests.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [WEBHOOK] To enable webhook, uncomment the following section
-# the following config is for teaching kustomize how to do kustomization for CRDs.
-#configurations:
-#- kustomizeconfig.yaml
+# Teaches kustomize that the conversion webhook clientConfig.service.name
+# is a Service reference, so namePrefix from config/default flows in.
+configurations:
+- kustomizeconfig.yaml

--- a/config/crd/patches/webhook_in_sopssecretmanifests.yaml
+++ b/config/crd/patches/webhook_in_sopssecretmanifests.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sopssecretmanifests.sops.stuttgart-things.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1"]
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_sopssecrets.yaml
+++ b/config/crd/patches/webhook_in_sopssecrets.yaml
@@ -1,0 +1,21 @@
+# Conversion-webhook config for SopsSecret. v1alpha1 and v1alpha2 schemas
+# are not isomorphic (v1alpha1.repositoryRef vs v1alpha2.sourceRef), so a
+# webhook is required to lossfully convert between them. The operator's
+# controller-runtime webhook server registers /convert automatically for
+# any scheme-registered type that implements Hub() / ConvertTo / ConvertFrom.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sopssecrets.sops.stuttgart-things.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1"]
+      clientConfig:
+        service:
+          # name + namespace are filled in by config/default/kustomization.yaml
+          # via the namePrefix and the cert-manager replacements blocks.
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,9 +18,11 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
+# The webhook Service backs the conversion webhook configured on
+# SopsSecret + SopsSecretManifest CRDs (config/crd/patches). Cert-manager
+# wiring is still scaffold-only — uncomment ../certmanager and the
+# CONVERSIONWEBHOOK replacements below to issue real serving certs.
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,7 @@
+# Webhook resources. Today the operator only serves a conversion webhook
+# (auto-registered by controller-runtime at /convert for any scheme-registered
+# type implementing Hub + ConvertTo/ConvertFrom). When a validating or
+# mutating webhook is added, generate manifests via `make manifests` and
+# add the resulting file to the resources list below.
+resources:
+- service.yaml

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: sops-secrets-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -79,6 +79,14 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// Force-sync: a changed reconcile-requested annotation drops the cache
+	// before the EnsureCached call, so the next fetch re-pulls from origin
+	// regardless of the configured commit/branch.
+	reqToken := gr.Annotations[ReconcileRequestAnnotation]
+	if reqToken != "" && reqToken != gr.Status.LastProcessedReconcileToken {
+		r.Registry.Forget(req.NamespacedName)
+	}
+
 	auth, err := r.resolveAuth(ctx, &gr)
 	if err != nil {
 		log.Error(err, "auth resolution failed")
@@ -113,6 +121,7 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	gr.Status.LastSyncedCommit = sha
 	gr.Status.CacheReady = true
+	gr.Status.LastProcessedReconcileToken = reqToken
 	gr.Status.ObservedGeneration = gr.Generation
 	short := sha
 	if len(short) > 7 {

--- a/internal/controller/gitsourced_happypath_test.go
+++ b/internal/controller/gitsourced_happypath_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
+	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/testutil"
 )
@@ -35,6 +36,19 @@ type gitFixture struct {
 	registry  *source.Registry
 	repoCRRef string // GitRepository CR name
 	keyRef    string // age-key Secret name
+}
+
+// gitSourceRef is shorthand for the v1alpha2 SourceRef pointing at a
+// GitRepository — used to keep the per-test SopsSecret/SopsSecretManifest
+// stanzas readable.
+func gitSourceRef(name, path string) sopsv1alpha2.SourceRef {
+	return sopsv1alpha2.SourceRef{
+		SourceRef: sopsv1alpha2.SourceKindRef{
+			Kind: sopsv1alpha2.SourceKindGitRepository,
+			Name: name,
+		},
+		Path: path,
+	}
 }
 
 var _ = Describe("Git-sourced happy paths (envtest)", func() {
@@ -106,17 +120,14 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			plain := []byte("db_user: alice\ndb_password: s3cret\napi_token: xyz\n")
 			fx := newGitFixture(prefix, "creds.enc.yaml", plain)
 
-			cr := &sopsv1alpha1.SopsSecret{
+			cr := &sopsv1alpha2.SopsSecret{
 				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
-				Spec: sopsv1alpha1.SopsSecretSpec{
-					Source: sopsv1alpha1.SourceRef{
-						RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: fx.repoCRRef},
-						Path:          "creds.enc.yaml",
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: gitSourceRef(fx.repoCRRef, "creds.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
 					},
-					Decryption: sopsv1alpha1.DecryptionSpec{
-						KeyRef: sopsv1alpha1.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
-					},
-					Data: []sopsv1alpha1.DataMapping{
+					Data: []sopsv1alpha2.DataMapping{
 						{Key: "DB_USER", From: "db_user"},
 						{Key: "DB_PASSWORD", From: "db_password"},
 					},
@@ -145,10 +156,8 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			Expect(string(target.Data["DB_PASSWORD"])).To(Equal("s3cret"))
 			Expect(target.Annotations[SourceCommitAnnotation]).NotTo(BeEmpty())
 
-			// Remove DB_PASSWORD, add API_TOKEN → next reconcile authoritatively
-			// replaces the target Secret's data.
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, cr)).To(Succeed())
-			cr.Spec.Data = []sopsv1alpha1.DataMapping{
+			cr.Spec.Data = []sopsv1alpha2.DataMapping{
 				{Key: "DB_USER", From: "db_user"},
 				{Key: "API_TOKEN", From: "api_token"},
 			}
@@ -171,7 +180,6 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			plain := []byte("db_user: alice\ndb_password: s3cret\n")
 			fx := newGitFixture(prefix, "adopt.enc.yaml", plain)
 
-			// Pre-existing Secret not managed by this operator.
 			pre := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        prefix,
@@ -186,17 +194,14 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			}
 			Expect(k8sClient.Create(ctx, pre)).To(Succeed())
 
-			cr := &sopsv1alpha1.SopsSecret{
+			cr := &sopsv1alpha2.SopsSecret{
 				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
-				Spec: sopsv1alpha1.SopsSecretSpec{
-					Source: sopsv1alpha1.SourceRef{
-						RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: fx.repoCRRef},
-						Path:          "adopt.enc.yaml",
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: gitSourceRef(fx.repoCRRef, "adopt.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
 					},
-					Decryption: sopsv1alpha1.DecryptionSpec{
-						KeyRef: sopsv1alpha1.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
-					},
-					Data: []sopsv1alpha1.DataMapping{
+					Data: []sopsv1alpha2.DataMapping{
 						{Key: "DB_USER", From: "db_user"},
 						{Key: "DB_PASSWORD", From: "db_password"},
 					},
@@ -209,7 +214,6 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 				Scheme:   k8sClient.Scheme(),
 				Registry: fx.registry,
 			}
-			// Finalizer add + actual reconcile. Adoption must be refused.
 			for range 2 {
 				_, err := reconr.Reconcile(ctx, reconcile.Request{
 					NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
@@ -217,7 +221,6 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// Pre-existing Secret must be untouched — no ManagedBy label, original data intact.
 			got := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, got)).To(Succeed())
 			Expect(got.Labels).NotTo(HaveKey(ManagedByLabel))
@@ -225,14 +228,12 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			Expect(string(got.Data["DB_USER"])).To(Equal("stale-user"))
 			Expect(got.Data).To(HaveKey("LEGACY_ONLY"))
 
-			// CR must report Applied=False with reason ApplyFailed.
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, cr)).To(Succeed())
-			applied := conditionByType(cr.Status.Conditions, sopsv1alpha1.ConditionApplied)
+			applied := conditionByType(cr.Status.Conditions, sopsv1alpha2.ConditionApplied)
 			Expect(applied).NotTo(BeNil())
 			Expect(applied.Status).To(Equal(metav1.ConditionFalse))
 			Expect(applied.Reason).To(Equal("ApplyFailed"))
 
-			// Flip adopt=true and re-reconcile.
 			cr.Spec.Target.Adopt = true
 			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
@@ -247,7 +248,6 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			Expect(got.Annotations[ContentHashAnnotation]).NotTo(BeEmpty())
 			Expect(string(got.Data["DB_USER"])).To(Equal("alice"))
 			Expect(string(got.Data["DB_PASSWORD"])).To(Equal("s3cret"))
-			// Data is authoritative after adoption — the legacy key is dropped.
 			Expect(got.Data).NotTo(HaveKey("LEGACY_ONLY"))
 		})
 
@@ -256,17 +256,14 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			plain := []byte("token: correct-horse\n")
 			fx := newGitFixture(prefix, "drift.enc.yaml", plain)
 
-			cr := &sopsv1alpha1.SopsSecret{
+			cr := &sopsv1alpha2.SopsSecret{
 				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
-				Spec: sopsv1alpha1.SopsSecretSpec{
-					Source: sopsv1alpha1.SourceRef{
-						RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: fx.repoCRRef},
-						Path:          "drift.enc.yaml",
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: gitSourceRef(fx.repoCRRef, "drift.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
 					},
-					Decryption: sopsv1alpha1.DecryptionSpec{
-						KeyRef: sopsv1alpha1.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
-					},
-					Data: []sopsv1alpha1.DataMapping{{Key: "TOKEN", From: "token"}},
+					Data: []sopsv1alpha2.DataMapping{{Key: "TOKEN", From: "token"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
@@ -288,7 +285,6 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			Expect(k8sClient.Get(ctx, key, target)).To(Succeed())
 			Expect(string(target.Data["TOKEN"])).To(Equal("correct-horse"))
 
-			// Out-of-band drift: overwrite TOKEN and add a rogue key.
 			target.Data["TOKEN"] = []byte("tampered")
 			target.Data["ROGUE"] = []byte("injected")
 			Expect(k8sClient.Update(ctx, target)).To(Succeed())
@@ -305,17 +301,14 @@ var _ = Describe("Git-sourced happy paths (envtest)", func() {
 			prefix := uniq("ss-fin")
 			fx := newGitFixture(prefix, "c.enc.yaml", []byte("x: 1\n"))
 
-			cr := &sopsv1alpha1.SopsSecret{
+			cr := &sopsv1alpha2.SopsSecret{
 				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
-				Spec: sopsv1alpha1.SopsSecretSpec{
-					Source: sopsv1alpha1.SourceRef{
-						RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: fx.repoCRRef},
-						Path:          "c.enc.yaml",
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: gitSourceRef(fx.repoCRRef, "c.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
 					},
-					Decryption: sopsv1alpha1.DecryptionSpec{
-						KeyRef: sopsv1alpha1.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
-					},
-					Data: []sopsv1alpha1.DataMapping{{Key: "X", From: "x"}},
+					Data: []sopsv1alpha2.DataMapping{{Key: "X", From: "x"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
@@ -363,19 +356,15 @@ stringData:
 			fx := newGitFixture(prefix, "sec.enc.yaml", manifest)
 
 			overrideName := prefix + "-override"
-			cr := &sopsv1alpha1.SopsSecretManifest{
+			cr := &sopsv1alpha2.SopsSecretManifest{
 				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
-				Spec: sopsv1alpha1.SopsSecretManifestSpec{
-					Source: sopsv1alpha1.SourceRef{
-						RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: fx.repoCRRef},
-						Path:          "sec.enc.yaml",
+				Spec: sopsv1alpha2.SopsSecretManifestSpec{
+					Source: gitSourceRef(fx.repoCRRef, "sec.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
 					},
-					Decryption: sopsv1alpha1.DecryptionSpec{
-						KeyRef: sopsv1alpha1.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
-					},
-					Target: sopsv1alpha1.ManifestTarget{
+					Target: sopsv1alpha2.ManifestTarget{
 						NameOverride: overrideName,
-						// namespace defaults to CR's — "default" — NOT "should-be-ignored".
 					},
 				},
 			}
@@ -400,11 +389,6 @@ stringData:
 			Expect(string(target.Data["username"])).To(Equal("alice"))
 			Expect(string(target.Data["password"])).To(Equal("s3cret"))
 
-			// The manifest's metadata.name was "manifest-name" — nameOverride
-			// should win, so no Secret with that name should exist in the
-			// CR's namespace. (envtest typically lacks a controller for
-			// namespace creation; we skip checking the manifest's claimed
-			// namespace, which `should-be-ignored` doesn't exist.)
 			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "manifest-name"}, &corev1.Secret{})
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})

--- a/internal/controller/inlinesopssecret_controller.go
+++ b/internal/controller/inlinesopssecret_controller.go
@@ -82,7 +82,10 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Resolve age key and decrypt the inline payload.
-	ageKey, err := keyresolve.Age(ctx, r.Client, is.Namespace, is.Spec.Decryption.KeyRef)
+	ageKey, err := keyresolve.Age(ctx, r.Client, is.Namespace, keyresolve.SecretKeyRef{
+		Name: is.Spec.Decryption.KeyRef.Name,
+		Key:  is.Spec.Decryption.KeyRef.Key,
+	})
 	if err != nil {
 		setStage(StageDecrypt)
 		return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "KeyResolveFailed", err.Error())
@@ -101,7 +104,7 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			setStage(StageDecrypt)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "ParseFailed", err.Error())
 		}
-		data, err := transform.ApplyMapping(flat, is.Spec.Data)
+		data, err := transform.ApplyMapping(flat, convertInlineDataMappings(is.Spec.Data))
 		if err != nil {
 			setStage(StageDecrypt)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "MappingFailed", err.Error())
@@ -157,11 +160,23 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			fmt.Sprintf("unknown mode %q", is.Spec.Mode))
 	}
 
+	is.Status.LastProcessedReconcileToken = is.Annotations[ReconcileRequestAnnotation]
 	is.Status.ObservedGeneration = is.Generation
 	if err := r.Status().Update(ctx, &is); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+func convertInlineDataMappings(in []sopsv1alpha1.DataMapping) []transform.DataMapping {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]transform.DataMapping, len(in))
+	for i, m := range in {
+		out[i] = transform.DataMapping{Key: m.Key, From: m.From}
+	}
+	return out
 }
 
 func (r *InlineSopsSecretReconciler) applyInlineMappingSecret(ctx context.Context, is *sopsv1alpha1.InlineSopsSecret, data map[string][]byte, hash string) error {

--- a/internal/controller/labels.go
+++ b/internal/controller/labels.go
@@ -69,6 +69,12 @@ const (
 	// Finalizer is set on every SopsSecret / SopsSecretManifest so the
 	// target Secret can be cleaned up on CR deletion.
 	Finalizer = "sops.stuttgart-things.com/finalizer"
+
+	// ReconcileRequestAnnotation, when changed, makes the next reconcile
+	// run the full pipeline regardless of cache state. The value is opaque
+	// (timestamp / UUID / commit / etc.) — the reconciler only checks
+	// whether it differs from status.lastProcessedReconcileToken.
+	ReconcileRequestAnnotation = "sops.stuttgart-things.com/reconcile-requested"
 )
 
 // FieldOwner is the server-side-apply / CreateOrUpdate field-manager name.

--- a/internal/controller/objectsource_controller.go
+++ b/internal/controller/objectsource_controller.go
@@ -73,6 +73,14 @@ func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	// Force-sync: a changed reconcile-requested annotation drops the cached
+	// content (and ETag) so the next EnsureObjectCached call performs an
+	// unconditional GET regardless of upstream If-None-Match semantics.
+	reqToken := os.Annotations[ReconcileRequestAnnotation]
+	if reqToken != "" && reqToken != os.Status.LastProcessedReconcileToken {
+		r.Registry.ForgetObject(req.NamespacedName)
+	}
+
 	// Validate spec oneOf. The CRD OpenAPI validation already blocks this
 	// at admission time, but keep a defensive check for in-cluster edits
 	// that could bypass validation (e.g. legacy clients).
@@ -116,6 +124,7 @@ func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	os.Status.LastSyncedETag = etag
 	os.Status.LastSyncedAt = &now
 	os.Status.CacheReady = true
+	os.Status.LastProcessedReconcileToken = reqToken
 	os.Status.ObservedGeneration = os.Generation
 
 	msg := "cache ready"

--- a/internal/controller/objectsourced_happypath_test.go
+++ b/internal/controller/objectsourced_happypath_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
+	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
+	"github.com/stuttgart-things/sops-secrets-operator/internal/testutil"
+)
+
+// objectSourceFixture mirrors gitFixture but for an ObjectSource: a local
+// httptest.Server is the upstream, the ObjectSource controller has been
+// run end-to-end so the Registry holds the cached encrypted bytes, and
+// the consumer (SopsSecret/SopsSecretManifest) reconciler reads back via
+// Registry.ReadObject.
+type objectSourceFixture struct {
+	registry *source.Registry
+	srcRef   string // ObjectSource CR name
+	keyRef   string // age-key Secret name
+	server   *httptest.Server
+	gets     *int32
+}
+
+func objectSourceRef(name, path string) sopsv1alpha2.SourceRef {
+	return sopsv1alpha2.SourceRef{
+		SourceRef: sopsv1alpha2.SourceKindRef{
+			Kind: sopsv1alpha2.SourceKindObjectSource,
+			Name: name,
+		},
+		Path: path,
+	}
+}
+
+var _ = Describe("ObjectSource-sourced happy paths (envtest)", func() {
+	const namespace = "default"
+	var counter int
+	var uniq func(prefix string) string
+
+	BeforeEach(func() {
+		counter++
+		uniq = func(prefix string) string { return fmt.Sprintf("%s-%d", prefix, counter) }
+	})
+
+	// newObjectSourceFixture spins up an httptest.Server that serves the
+	// SOPS-encrypted bytes for `plaintext`, creates an ObjectSource pointing
+	// at it, runs the ObjectSourceReconciler twice to populate the Registry,
+	// and returns the bits a consumer test needs to wire up its CR.
+	newObjectSourceFixture := func(prefix string, plaintext []byte) *objectSourceFixture {
+		GinkgoHelper()
+		age := testutil.GenerateAge(GinkgoT())
+		ct := testutil.EncryptYAML(GinkgoT(), age.PublicKey, plaintext)
+
+		const etag = `"v1"`
+		var gets int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "no", http.StatusMethodNotAllowed)
+				return
+			}
+			atomic.AddInt32(&gets, 1)
+			if r.Header.Get("If-None-Match") == etag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("ETag", etag)
+			_, _ = w.Write(ct)
+		}))
+
+		keyRef := prefix + "-age-key"
+		Expect(k8sClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: keyRef, Namespace: namespace},
+			Data:       map[string][]byte{"age.agekey": []byte(age.PrivateKey)},
+		})).To(Succeed())
+
+		srcCRName := prefix + "-src"
+		Expect(k8sClient.Create(ctx, &sopsv1alpha2.ObjectSource{
+			ObjectMeta: metav1.ObjectMeta{Name: srcCRName, Namespace: namespace},
+			Spec:       sopsv1alpha2.ObjectSourceSpec{URL: srv.URL},
+		})).To(Succeed())
+
+		registry := source.NewRegistry()
+		osr := &ObjectSourceReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sClient.Scheme(),
+			Registry: registry,
+		}
+		_, err := osr.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: namespace, Name: srcCRName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		got := &sopsv1alpha2.ObjectSource{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: srcCRName}, got)).To(Succeed())
+		Expect(got.Status.CacheReady).To(BeTrue(), "ObjectSource should be ready; conditions=%+v", got.Status.Conditions)
+		Expect(got.Status.LastSyncedETag).To(Equal(etag))
+
+		return &objectSourceFixture{
+			registry: registry,
+			srcRef:   srcCRName,
+			keyRef:   keyRef,
+			server:   srv,
+			gets:     &gets,
+		}
+	}
+
+	Context("SopsSecret backed by an ObjectSource (URL mode)", func() {
+		It("materializes a Secret with exactly the mapped keys", func() {
+			prefix := uniq("ss-os-e2e")
+			plain := []byte("db_user: alice\ndb_password: s3cret\napi_token: xyz\n")
+			fx := newObjectSourceFixture(prefix, plain)
+			defer fx.server.Close()
+
+			cr := &sopsv1alpha2.SopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					// path is unused for URL-mode ObjectSource but spec.source.path
+					// is required by the schema; supply a placeholder.
+					Source: objectSourceRef(fx.srcRef, "creds.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha2.DataMapping{
+						{Key: "DB_USER", From: "db_user"},
+						{Key: "DB_PASSWORD", From: "db_password"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := &SopsSecretReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Registry: fx.registry,
+			}
+			for range 2 {
+				_, err := r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, target)).To(Succeed())
+			Expect(target.Data).To(HaveKey("DB_USER"))
+			Expect(target.Data).To(HaveKey("DB_PASSWORD"))
+			Expect(target.Data).NotTo(HaveKey("API_TOKEN"))
+			Expect(string(target.Data["DB_USER"])).To(Equal("alice"))
+			Expect(string(target.Data["DB_PASSWORD"])).To(Equal("s3cret"))
+			// ETag is recorded as the "revision" in the source-commit annotation.
+			Expect(target.Annotations[SourceCommitAnnotation]).To(Equal(`"v1"`))
+		})
+
+		It("reverts drift when the target Secret is edited out of band", func() {
+			prefix := uniq("ss-os-drift")
+			fx := newObjectSourceFixture(prefix, []byte("token: correct-horse\n"))
+			defer fx.server.Close()
+
+			cr := &sopsv1alpha2.SopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: objectSourceRef(fx.srcRef, "drift.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha2.DataMapping{{Key: "TOKEN", From: "token"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := &SopsSecretReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Registry: fx.registry,
+			}
+			for range 2 {
+				_, err := r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			target := &corev1.Secret{}
+			key := types.NamespacedName{Namespace: namespace, Name: prefix}
+			Expect(k8sClient.Get(ctx, key, target)).To(Succeed())
+			Expect(string(target.Data["TOKEN"])).To(Equal("correct-horse"))
+
+			target.Data["TOKEN"] = []byte("tampered")
+			Expect(k8sClient.Update(ctx, target)).To(Succeed())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, key, target)).To(Succeed())
+			Expect(string(target.Data["TOKEN"])).To(Equal("correct-horse"))
+		})
+	})
+
+	Context("SopsSecretManifest backed by an ObjectSource", func() {
+		It("applies the decrypted manifest with authoritative namespace", func() {
+			prefix := uniq("sm-os-e2e")
+			manifest := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: manifest-name
+  namespace: should-be-ignored
+type: kubernetes.io/basic-auth
+stringData:
+  username: alice
+  password: s3cret
+`)
+			fx := newObjectSourceFixture(prefix, manifest)
+			defer fx.server.Close()
+
+			overrideName := prefix + "-override"
+			cr := &sopsv1alpha2.SopsSecretManifest{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha2.SopsSecretManifestSpec{
+					Source: objectSourceRef(fx.srcRef, "sec.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
+					},
+					Target: sopsv1alpha2.ManifestTarget{NameOverride: overrideName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := &SopsSecretManifestReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Registry: fx.registry,
+			}
+			for range 2 {
+				_, err := r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			target := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: overrideName}, target)).To(Succeed())
+			Expect(target.Namespace).To(Equal(namespace))
+			Expect(target.Type).To(Equal(corev1.SecretType("kubernetes.io/basic-auth")))
+			Expect(string(target.Data["username"])).To(Equal("alice"))
+			Expect(string(target.Data["password"])).To(Equal("s3cret"))
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "manifest-name"}, &corev1.Secret{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("force-sync annotation", func() {
+		It("on the SopsSecret consumer: records the token after re-applying", func() {
+			prefix := uniq("ss-os-force")
+			fx := newObjectSourceFixture(prefix, []byte("token: t1\n"))
+			defer fx.server.Close()
+
+			cr := &sopsv1alpha2.SopsSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: objectSourceRef(fx.srcRef, "tok.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
+					},
+					Data: []sopsv1alpha2.DataMapping{{Key: "TOKEN", From: "token"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := &SopsSecretReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Registry: fx.registry,
+			}
+			for range 2 {
+				_, err := r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, cr)).To(Succeed())
+			Expect(cr.Status.LastProcessedReconcileToken).To(BeEmpty())
+
+			cr.Annotations = map[string]string{ReconcileRequestAnnotation: "now-1"}
+			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: prefix}, cr)).To(Succeed())
+			Expect(cr.Status.LastProcessedReconcileToken).To(Equal("now-1"))
+		})
+
+		It("on the ObjectSource: invalidates the cache and re-fetches upstream", func() {
+			prefix := uniq("os-force-src")
+			fx := newObjectSourceFixture(prefix, []byte("k: v\n"))
+			defer fx.server.Close()
+			before := atomic.LoadInt32(fx.gets)
+
+			osr := &ObjectSourceReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Registry: fx.registry,
+			}
+
+			// A no-op reconcile: ETag matches, upstream returns 304.
+			_, err := osr.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: fx.srcRef},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			afterIdle := atomic.LoadInt32(fx.gets)
+			Expect(afterIdle).To(Equal(before + 1))
+
+			// Annotate to force re-fetch. The reconciler must drop the cached
+			// ETag and issue an unconditional GET, which the upstream answers
+			// with 200 (counted as a fresh hit).
+			os := &sopsv1alpha2.ObjectSource{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: fx.srcRef}, os)).To(Succeed())
+			os.Annotations = map[string]string{ReconcileRequestAnnotation: "force-1"}
+			Expect(k8sClient.Update(ctx, os)).To(Succeed())
+
+			_, err = osr.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: fx.srcRef},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			afterForce := atomic.LoadInt32(fx.gets)
+			Expect(afterForce).To(Equal(afterIdle + 1))
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: fx.srcRef}, os)).To(Succeed())
+			Expect(os.Status.LastProcessedReconcileToken).To(Equal("force-1"))
+		})
+	})
+})

--- a/internal/controller/sopssecret_controller.go
+++ b/internal/controller/sopssecret_controller.go
@@ -32,14 +32,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
+	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/decrypt"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/keyresolve"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/transform"
 )
 
-// SopsSecretRepoRefIndex is a field index on SopsSecret.spec.source.repositoryRef.name.
-const SopsSecretRepoRefIndex = ".spec.source.repositoryRef.name"
+// Field indexers on SopsSecret. They split GitRepository-backed and
+// ObjectSource-backed CRs so each Watches() can map only the dependents
+// that reference the changed source.
+const (
+	SopsSecretGitRefIndex    = ".spec.source.sourceRef.git.name"
+	SopsSecretObjectRefIndex = ".spec.source.sourceRef.object.name"
+)
 
 // SopsSecretReconciler reconciles SopsSecret objects (mapping mode).
 type SopsSecretReconciler struct {
@@ -58,7 +64,7 @@ func (r *SopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	setStage, finish := trackReconcile("SopsSecret")
 	defer finish()
 
-	var ss sopsv1alpha1.SopsSecret
+	var ss sopsv1alpha2.SopsSecret
 	if err := r.Get(ctx, req.NamespacedName, &ss); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -85,68 +91,53 @@ func (r *SopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	// Resolve GitRepository and check it's ready.
-	var repo sopsv1alpha1.GitRepository
-	repoKey := client.ObjectKey{Namespace: ss.Namespace, Name: ss.Spec.Source.RepositoryRef.Name}
-	if err := r.Get(ctx, repoKey, &repo); err != nil {
-		msg := err.Error()
-		if apierrors.IsNotFound(err) {
-			msg = fmt.Sprintf("GitRepository %q not found", ss.Spec.Source.RepositoryRef.Name)
-		}
+	// Resolve the source CR by sourceRef.Kind, fetch the encrypted bytes
+	// plus a "revision" string (commit SHA for git, ETag for object).
+	content, revision, srcErr := r.fetchSource(ctx, &ss)
+	if srcErr != nil {
 		setStage(StageFetch)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionSourceReady, "SourceMissing", msg)
+		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionSourceReady, srcErr.reason, srcErr.msg)
 	}
-	if !isSourceReady(&repo) {
-		setStage(StageFetch)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionSourceReady, "SourceNotReady",
-			fmt.Sprintf("GitRepository %q is not ready", repo.Name))
-	}
-	setCondition(&ss.Status.Conditions, sopsv1alpha1.ConditionSourceReady, metav1.ConditionTrue, "Ready", "source is ready")
+	setCondition(&ss.Status.Conditions, sopsv1alpha2.ConditionSourceReady, metav1.ConditionTrue, "Ready", "source is ready")
 
-	// Read encrypted file from the cached repo.
-	content, commitSHA, err := r.Registry.Read(repoKey, ss.Spec.Source.Path)
-	if err != nil {
-		setStage(StageFetch)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionSourceReady, "ReadFailed", err.Error())
-	}
-
-	// Resolve age key and decrypt.
-	ageKey, err := keyresolve.Age(ctx, r.Client, ss.Namespace, ss.Spec.Decryption.KeyRef)
+	ageKey, err := keyresolve.Age(ctx, r.Client, ss.Namespace, keyresolve.SecretKeyRef{
+		Name: ss.Spec.Decryption.KeyRef.Name,
+		Key:  ss.Spec.Decryption.KeyRef.Key,
+	})
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionDecrypted, "KeyResolveFailed", err.Error())
+		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "KeyResolveFailed", err.Error())
 	}
 	plaintext, err := decrypt.DecryptAge(content, ss.Spec.Source.Path, ageKey)
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionDecrypted, "DecryptFailed", err.Error())
+		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "DecryptFailed", err.Error())
 	}
 
-	// Parse flat YAML, enforce flat-only guard, apply mapping.
 	flat, err := transform.ParseFlatYAML(plaintext)
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionDecrypted, "ParseFailed", err.Error())
+		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "ParseFailed", err.Error())
 	}
-	data, err := transform.ApplyMapping(flat, ss.Spec.Data)
+	data, err := transform.ApplyMapping(flat, convertSpecDataMappings(ss.Spec.Data))
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionDecrypted, "MappingFailed", err.Error())
+		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "MappingFailed", err.Error())
 	}
-	setCondition(&ss.Status.Conditions, sopsv1alpha1.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + mapping ok")
+	setCondition(&ss.Status.Conditions, sopsv1alpha2.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + mapping ok")
 
-	// Apply target Secret.
 	hash := transform.HashSecretData(data)
-	if err := r.applyTargetSecret(ctx, &ss, data, hash, commitSHA); err != nil {
+	if err := r.applyTargetSecret(ctx, &ss, data, hash, revision); err != nil {
 		log.Error(err, "apply target secret failed")
 		setStage(StageApply)
-		return r.failStatus(ctx, &ss, sopsv1alpha1.ConditionApplied, "ApplyFailed", err.Error())
+		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionApplied, "ApplyFailed", err.Error())
 	}
-	setCondition(&ss.Status.Conditions, sopsv1alpha1.ConditionApplied, metav1.ConditionTrue, "Applied",
+	setCondition(&ss.Status.Conditions, sopsv1alpha2.ConditionApplied, metav1.ConditionTrue, "Applied",
 		fmt.Sprintf("applied %d keys", len(data)))
 
 	ss.Status.LastAppliedHash = hash
-	ss.Status.LastSyncedCommit = commitSHA
+	ss.Status.LastSyncedCommit = revision
+	ss.Status.LastProcessedReconcileToken = ss.Annotations[ReconcileRequestAnnotation]
 	ss.Status.ObservedGeneration = ss.Generation
 	if err := r.Status().Update(ctx, &ss); err != nil {
 		return ctrl.Result{}, err
@@ -154,7 +145,74 @@ func (r *SopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-func (r *SopsSecretReconciler) applyTargetSecret(ctx context.Context, ss *sopsv1alpha1.SopsSecret, data map[string][]byte, hash, commitSHA string) error {
+// sourceFetchError carries a stable reason + message for failStatus.
+type sourceFetchError struct {
+	reason string
+	msg    string
+}
+
+func (e *sourceFetchError) Error() string { return e.msg }
+
+// fetchSource resolves spec.source.sourceRef.kind to either a GitRepository
+// or ObjectSource, verifies its readiness, and reads the encrypted file
+// from the Registry. The "revision" is the git commit SHA or object ETag
+// observed at read time.
+//
+// Force-sync at the consumer level (an annotation on the SopsSecret itself)
+// only marks the next reconcile as "honored": every reconcile already runs
+// the full read/decrypt/apply pipeline, so there is nothing to skip. To
+// force a fresh upstream fetch, annotate the source CR — those reconcilers
+// invalidate the cache before EnsureCached / EnsureObjectCached runs again.
+func (r *SopsSecretReconciler) fetchSource(ctx context.Context, ss *sopsv1alpha2.SopsSecret) ([]byte, string, *sourceFetchError) {
+	kind := ss.Spec.Source.SourceRef.Kind
+	name := ss.Spec.Source.SourceRef.Name
+	path := ss.Spec.Source.Path
+	srcKey := client.ObjectKey{Namespace: ss.Namespace, Name: name}
+
+	switch kind {
+	case sopsv1alpha2.SourceKindGitRepository:
+		// Fetch the storage version (v1alpha1) so envtest can run without
+		// a conversion webhook server. v1alpha1 and v1alpha2 GitRepository
+		// schemas are isomorphic, so this is purely a wire-format choice.
+		var repo sopsv1alpha1.GitRepository
+		if err := r.Get(ctx, srcKey, &repo); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, "", &sourceFetchError{"SourceMissing", fmt.Sprintf("GitRepository %q not found", name)}
+			}
+			return nil, "", &sourceFetchError{"SourceMissing", err.Error()}
+		}
+		if !isGitSourceReady(&repo) {
+			return nil, "", &sourceFetchError{"SourceNotReady", fmt.Sprintf("GitRepository %q is not ready", name)}
+		}
+		content, sha, err := r.Registry.Read(srcKey, path)
+		if err != nil {
+			return nil, "", &sourceFetchError{"ReadFailed", err.Error()}
+		}
+		return content, sha, nil
+
+	case sopsv1alpha2.SourceKindObjectSource:
+		var os sopsv1alpha2.ObjectSource
+		if err := r.Get(ctx, srcKey, &os); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, "", &sourceFetchError{"SourceMissing", fmt.Sprintf("ObjectSource %q not found", name)}
+			}
+			return nil, "", &sourceFetchError{"SourceMissing", err.Error()}
+		}
+		if !isObjectSourceReady(&os) {
+			return nil, "", &sourceFetchError{"SourceNotReady", fmt.Sprintf("ObjectSource %q is not ready", name)}
+		}
+		content, etag, err := r.Registry.ReadObject(ctx, srcKey, path)
+		if err != nil {
+			return nil, "", &sourceFetchError{"ReadFailed", err.Error()}
+		}
+		return content, etag, nil
+
+	default:
+		return nil, "", &sourceFetchError{"UnknownSourceKind", fmt.Sprintf("unsupported sourceRef.kind %q", kind)}
+	}
+}
+
+func (r *SopsSecretReconciler) applyTargetSecret(ctx context.Context, ss *sopsv1alpha2.SopsSecret, data map[string][]byte, hash, revision string) error {
 	secret := &corev1.Secret{}
 	secret.Name = targetName(ss)
 	secret.Namespace = targetNamespace(ss)
@@ -175,36 +233,32 @@ func (r *SopsSecretReconciler) applyTargetSecret(ctx context.Context, ss *sopsv1
 			}
 		}
 
-		// Labels.
 		if secret.Labels == nil {
 			secret.Labels = map[string]string{}
 		}
 		secret.Labels[ManagedByLabel] = ManagedByValue
 
-		// Annotations.
 		if secret.Annotations == nil {
 			secret.Annotations = map[string]string{}
 		}
 		secret.Annotations[OwnerAnnotation] = ownerKey
 		secret.Annotations[OwnerUIDAnnotation] = string(ss.UID)
 		secret.Annotations[ContentHashAnnotation] = hash
-		secret.Annotations[SourceCommitAnnotation] = commitSHA
+		secret.Annotations[SourceCommitAnnotation] = revision
 
-		// Type.
 		if ss.Spec.Target.Type != "" {
 			secret.Type = ss.Spec.Target.Type
 		} else if secret.Type == "" {
 			secret.Type = corev1.SecretTypeOpaque
 		}
 
-		// Data is authoritative: drop any key not declared in spec.data.
 		secret.Data = data
 		return nil
 	})
 	return err
 }
 
-func (r *SopsSecretReconciler) deleteOwnedSecret(ctx context.Context, ss *sopsv1alpha1.SopsSecret, name, namespace string) error {
+func (r *SopsSecretReconciler) deleteOwnedSecret(ctx context.Context, ss *sopsv1alpha2.SopsSecret, name, namespace string) error {
 	var sec corev1.Secret
 	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &sec); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -213,16 +267,16 @@ func (r *SopsSecretReconciler) deleteOwnedSecret(ctx context.Context, ss *sopsv1
 		return err
 	}
 	if sec.Labels[ManagedByLabel] != ManagedByValue {
-		return nil // not ours; leave it
+		return nil
 	}
 	ownerKey := fmt.Sprintf("SopsSecret/%s/%s", ss.Namespace, ss.Name)
 	if sec.Annotations[OwnerAnnotation] != ownerKey {
-		return nil // managed by this operator, but a different CR owns it
+		return nil
 	}
 	return client.IgnoreNotFound(r.Delete(ctx, &sec))
 }
 
-func (r *SopsSecretReconciler) failStatus(ctx context.Context, ss *sopsv1alpha1.SopsSecret, condType, reason, msg string) (ctrl.Result, error) {
+func (r *SopsSecretReconciler) failStatus(ctx context.Context, ss *sopsv1alpha2.SopsSecret, condType, reason, msg string) (ctrl.Result, error) {
 	setCondition(&ss.Status.Conditions, condType, metav1.ConditionFalse, reason, msg)
 	if err := r.Status().Update(ctx, ss); err != nil {
 		return ctrl.Result{}, err
@@ -230,21 +284,21 @@ func (r *SopsSecretReconciler) failStatus(ctx context.Context, ss *sopsv1alpha1.
 	return ctrl.Result{RequeueAfter: retryAfter}, nil
 }
 
-func targetName(ss *sopsv1alpha1.SopsSecret) string {
+func targetName(ss *sopsv1alpha2.SopsSecret) string {
 	if ss.Spec.Target.Name != "" {
 		return ss.Spec.Target.Name
 	}
 	return ss.Name
 }
 
-func targetNamespace(ss *sopsv1alpha1.SopsSecret) string {
+func targetNamespace(ss *sopsv1alpha2.SopsSecret) string {
 	if ss.Spec.Target.Namespace != "" {
 		return ss.Spec.Target.Namespace
 	}
 	return ss.Namespace
 }
 
-func isSourceReady(repo *sopsv1alpha1.GitRepository) bool {
+func isGitSourceReady(repo *sopsv1alpha1.GitRepository) bool {
 	for _, c := range repo.Status.Conditions {
 		if c.Type == sopsv1alpha1.ConditionSourceReady {
 			return c.Status == metav1.ConditionTrue
@@ -253,31 +307,77 @@ func isSourceReady(repo *sopsv1alpha1.GitRepository) bool {
 	return false
 }
 
+func isObjectSourceReady(os *sopsv1alpha2.ObjectSource) bool {
+	for _, c := range os.Status.Conditions {
+		if c.Type == ObjectConditionSourceReady {
+			return c.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func convertSpecDataMappings(in []sopsv1alpha2.DataMapping) []transform.DataMapping {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]transform.DataMapping, len(in))
+	for i, m := range in {
+		out[i] = transform.DataMapping{Key: m.Key, From: m.From}
+	}
+	return out
+}
+
 func (r *SopsSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&sopsv1alpha1.SopsSecret{},
-		SopsSecretRepoRefIndex,
+		&sopsv1alpha2.SopsSecret{},
+		SopsSecretGitRefIndex,
 		func(obj client.Object) []string {
-			s := obj.(*sopsv1alpha1.SopsSecret)
-			return []string{s.Spec.Source.RepositoryRef.Name}
+			s := obj.(*sopsv1alpha2.SopsSecret)
+			if s.Spec.Source.SourceRef.Kind != sopsv1alpha2.SourceKindGitRepository {
+				return nil
+			}
+			return []string{s.Spec.Source.SourceRef.Name}
+		},
+	); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&sopsv1alpha2.SopsSecret{},
+		SopsSecretObjectRefIndex,
+		func(obj client.Object) []string {
+			s := obj.(*sopsv1alpha2.SopsSecret)
+			if s.Spec.Source.SourceRef.Kind != sopsv1alpha2.SourceKindObjectSource {
+				return nil
+			}
+			return []string{s.Spec.Source.SourceRef.Name}
 		},
 	); err != nil {
 		return err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&sopsv1alpha1.SopsSecret{}).
-		Watches(&sopsv1alpha1.GitRepository{}, handler.EnqueueRequestsFromMapFunc(r.mapRepoToSopsSecrets)).
+		For(&sopsv1alpha2.SopsSecret{}).
+		Watches(&sopsv1alpha1.GitRepository{}, handler.EnqueueRequestsFromMapFunc(r.mapGitRepoToSopsSecrets)).
+		Watches(&sopsv1alpha2.ObjectSource{}, handler.EnqueueRequestsFromMapFunc(r.mapObjectSourceToSopsSecrets)).
 		Named("sopssecret").
 		Complete(r)
 }
 
-func (r *SopsSecretReconciler) mapRepoToSopsSecrets(ctx context.Context, obj client.Object) []reconcile.Request {
-	var list sopsv1alpha1.SopsSecretList
+func (r *SopsSecretReconciler) mapGitRepoToSopsSecrets(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapSourceToSopsSecrets(ctx, obj, SopsSecretGitRefIndex)
+}
+
+func (r *SopsSecretReconciler) mapObjectSourceToSopsSecrets(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapSourceToSopsSecrets(ctx, obj, SopsSecretObjectRefIndex)
+}
+
+func (r *SopsSecretReconciler) mapSourceToSopsSecrets(ctx context.Context, obj client.Object, index string) []reconcile.Request {
+	var list sopsv1alpha2.SopsSecretList
 	if err := r.List(ctx, &list,
 		client.InNamespace(obj.GetNamespace()),
-		client.MatchingFields{SopsSecretRepoRefIndex: obj.GetName()},
+		client.MatchingFields{index: obj.GetName()},
 	); err != nil {
 		return nil
 	}

--- a/internal/controller/sopssecret_controller_test.go
+++ b/internal/controller/sopssecret_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
+	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
 )
 
@@ -40,23 +41,26 @@ var _ = Describe("SopsSecret Controller", func() {
 		uniqueName = func(prefix string) string { return fmt.Sprintf("%s-%d", prefix, counter) }
 	})
 
-	makeCR := func(name, repoRef string) *sopsv1alpha1.SopsSecret {
-		return &sopsv1alpha1.SopsSecret{
+	makeCR := func(name, repoRef string) *sopsv1alpha2.SopsSecret {
+		return &sopsv1alpha2.SopsSecret{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Spec: sopsv1alpha1.SopsSecretSpec{
-				Source: sopsv1alpha1.SourceRef{
-					RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: repoRef},
-					Path:          "secrets.enc.yaml",
+			Spec: sopsv1alpha2.SopsSecretSpec{
+				Source: sopsv1alpha2.SourceRef{
+					SourceRef: sopsv1alpha2.SourceKindRef{
+						Kind: sopsv1alpha2.SourceKindGitRepository,
+						Name: repoRef,
+					},
+					Path: "secrets.enc.yaml",
 				},
-				Decryption: sopsv1alpha1.DecryptionSpec{
-					KeyRef: sopsv1alpha1.SecretKeyRef{Name: "age-key", Key: "age.agekey"},
+				Decryption: sopsv1alpha2.DecryptionSpec{
+					KeyRef: sopsv1alpha2.SecretKeyRef{Name: "age-key", Key: "age.agekey"},
 				},
-				Data: []sopsv1alpha1.DataMapping{{Key: "DB_PASSWORD", From: "db_password"}},
+				Data: []sopsv1alpha2.DataMapping{{Key: "DB_PASSWORD", From: "db_password"}},
 			},
 		}
 	}
 
-	reconcileOnce := func(name string) *sopsv1alpha1.SopsSecret {
+	reconcileOnce := func(name string) *sopsv1alpha2.SopsSecret {
 		r := &SopsSecretReconciler{
 			Client:   k8sClient,
 			Scheme:   k8sClient.Scheme(),
@@ -67,12 +71,12 @@ var _ = Describe("SopsSecret Controller", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		out := &sopsv1alpha1.SopsSecret{}
+		out := &sopsv1alpha2.SopsSecret{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, out)).To(Succeed())
 		return out
 	}
 
-	condition := func(ss *sopsv1alpha1.SopsSecret, t string) *metav1.Condition {
+	condition := func(ss *sopsv1alpha2.SopsSecret, t string) *metav1.Condition {
 		for i := range ss.Status.Conditions {
 			if ss.Status.Conditions[i].Type == t {
 				return &ss.Status.Conditions[i]
@@ -94,7 +98,7 @@ var _ = Describe("SopsSecret Controller", func() {
 				NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
 			})
 
-			got := &sopsv1alpha1.SopsSecret{}
+			got := &sopsv1alpha2.SopsSecret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, got)).To(Succeed())
 			Expect(got.Finalizers).To(ContainElement(Finalizer))
 
@@ -107,12 +111,10 @@ var _ = Describe("SopsSecret Controller", func() {
 			name := uniqueName("ss-no-repo")
 			Expect(k8sClient.Create(ctx, makeCR(name, "missing-repo"))).To(Succeed())
 
-			// First reconcile adds finalizer and requeues.
 			_ = reconcileOnce(name)
-			// Second reconcile reaches the source-resolution path.
 			got := reconcileOnce(name)
 
-			c := condition(got, sopsv1alpha1.ConditionSourceReady)
+			c := condition(got, sopsv1alpha2.ConditionSourceReady)
 			Expect(c).NotTo(BeNil())
 			Expect(c.Status).To(Equal(metav1.ConditionFalse))
 			Expect(c.Reason).To(Equal("SourceMissing"))
@@ -124,7 +126,6 @@ var _ = Describe("SopsSecret Controller", func() {
 			name := uniqueName("ss-repo-not-ready")
 			repoName := name + "-repo"
 
-			// Create a GitRepository CR without setting SourceReady=True.
 			Expect(k8sClient.Create(ctx, &sopsv1alpha1.GitRepository{
 				ObjectMeta: metav1.ObjectMeta{Name: repoName, Namespace: namespace},
 				Spec:       sopsv1alpha1.GitRepositorySpec{URL: "https://example.invalid/repo.git"},
@@ -134,7 +135,7 @@ var _ = Describe("SopsSecret Controller", func() {
 			_ = reconcileOnce(name)
 			got := reconcileOnce(name)
 
-			c := condition(got, sopsv1alpha1.ConditionSourceReady)
+			c := condition(got, sopsv1alpha2.ConditionSourceReady)
 			Expect(c).NotTo(BeNil())
 			Expect(c.Status).To(Equal(metav1.ConditionFalse))
 			Expect(c.Reason).To(Equal("SourceNotReady"))
@@ -144,17 +145,20 @@ var _ = Describe("SopsSecret Controller", func() {
 	Context("CRD schema validation", func() {
 		It("rejects a SopsSecret with empty data slice", func() {
 			name := uniqueName("ss-bad-schema")
-			bad := &sopsv1alpha1.SopsSecret{
+			bad := &sopsv1alpha2.SopsSecret{
 				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-				Spec: sopsv1alpha1.SopsSecretSpec{
-					Source: sopsv1alpha1.SourceRef{
-						RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: "r"},
-						Path:          "x.yaml",
+				Spec: sopsv1alpha2.SopsSecretSpec{
+					Source: sopsv1alpha2.SourceRef{
+						SourceRef: sopsv1alpha2.SourceKindRef{
+							Kind: sopsv1alpha2.SourceKindGitRepository,
+							Name: "r",
+						},
+						Path: "x.yaml",
 					},
-					Decryption: sopsv1alpha1.DecryptionSpec{
-						KeyRef: sopsv1alpha1.SecretKeyRef{Name: "k", Key: "age"},
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: "k", Key: "age"},
 					},
-					Data: []sopsv1alpha1.DataMapping{},
+					Data: []sopsv1alpha2.DataMapping{},
 				},
 			}
 			err := k8sClient.Create(ctx, bad)

--- a/internal/controller/sopssecretmanifest_controller.go
+++ b/internal/controller/sopssecretmanifest_controller.go
@@ -33,15 +33,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
+	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/decrypt"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/keyresolve"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/transform"
 )
 
-// SopsSecretManifestRepoRefIndex is a field index on
-// SopsSecretManifest.spec.source.repositoryRef.name.
-const SopsSecretManifestRepoRefIndex = ".spec.source.repositoryRef.name.manifest"
+const (
+	SopsSecretManifestGitRefIndex    = ".spec.source.sourceRef.git.name.manifest"
+	SopsSecretManifestObjectRefIndex = ".spec.source.sourceRef.object.name.manifest"
+)
 
 // SopsSecretManifestReconciler reconciles SopsSecretManifest objects (pass-through mode).
 type SopsSecretManifestReconciler struct {
@@ -59,7 +61,7 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	setStage, finish := trackReconcile("SopsSecretManifest")
 	defer finish()
 
-	var sm sopsv1alpha1.SopsSecretManifest
+	var sm sopsv1alpha2.SopsSecretManifest
 	if err := r.Get(ctx, req.NamespacedName, &sm); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -86,51 +88,34 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	// Source GitRepository must be ready.
-	var repo sopsv1alpha1.GitRepository
-	repoKey := client.ObjectKey{Namespace: sm.Namespace, Name: sm.Spec.Source.RepositoryRef.Name}
-	if err := r.Get(ctx, repoKey, &repo); err != nil {
-		msg := err.Error()
-		if apierrors.IsNotFound(err) {
-			msg = fmt.Sprintf("GitRepository %q not found", sm.Spec.Source.RepositoryRef.Name)
-		}
+	content, revision, srcErr := r.fetchManifestSource(ctx, &sm)
+	if srcErr != nil {
 		setStage(StageFetch)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionSourceReady, "SourceMissing", msg)
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionSourceReady, srcErr.reason, srcErr.msg)
 	}
-	if !isSourceReady(&repo) {
-		setStage(StageFetch)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionSourceReady, "SourceNotReady",
-			fmt.Sprintf("GitRepository %q is not ready", repo.Name))
-	}
-	setCondition(&sm.Status.Conditions, sopsv1alpha1.ConditionSourceReady, metav1.ConditionTrue, "Ready", "source is ready")
+	setCondition(&sm.Status.Conditions, sopsv1alpha2.ConditionSourceReady, metav1.ConditionTrue, "Ready", "source is ready")
 
-	// Read + decrypt.
-	content, commitSHA, err := r.Registry.Read(repoKey, sm.Spec.Source.Path)
-	if err != nil {
-		setStage(StageFetch)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionSourceReady, "ReadFailed", err.Error())
-	}
-	ageKey, err := keyresolve.Age(ctx, r.Client, sm.Namespace, sm.Spec.Decryption.KeyRef)
+	ageKey, err := keyresolve.Age(ctx, r.Client, sm.Namespace, keyresolve.SecretKeyRef{
+		Name: sm.Spec.Decryption.KeyRef.Name,
+		Key:  sm.Spec.Decryption.KeyRef.Key,
+	})
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionDecrypted, "KeyResolveFailed", err.Error())
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "KeyResolveFailed", err.Error())
 	}
 	plaintext, err := decrypt.DecryptAge(content, sm.Spec.Source.Path, ageKey)
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionDecrypted, "DecryptFailed", err.Error())
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "DecryptFailed", err.Error())
 	}
 
-	// Parse decrypted manifest into a Secret, enforcing the whitelist.
 	parsed, err := transform.ParseManifest(plaintext)
 	if err != nil {
 		setStage(StageDecrypt)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionDecrypted, "ParseFailed", err.Error())
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "ParseFailed", err.Error())
 	}
 	transform.NormalizeSecretData(parsed)
 
-	// Resolve target identity. Namespace is authoritative from the CR;
-	// whatever the manifest claimed is ignored.
 	targetNS := sm.Spec.Target.Namespace
 	if targetNS == "" {
 		targetNS = sm.Namespace
@@ -141,22 +126,23 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 	if targetName == "" {
 		setStage(StageDecrypt)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionDecrypted, "NameMissing",
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "NameMissing",
 			"manifest has no metadata.name and target.nameOverride is not set")
 	}
-	setCondition(&sm.Status.Conditions, sopsv1alpha1.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + validation ok")
+	setCondition(&sm.Status.Conditions, sopsv1alpha2.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + validation ok")
 
 	hash := transform.HashManifestSecret(parsed)
-	if err := r.applyManifestSecret(ctx, &sm, parsed, targetName, targetNS, hash, commitSHA); err != nil {
+	if err := r.applyManifestSecret(ctx, &sm, parsed, targetName, targetNS, hash, revision); err != nil {
 		log.Error(err, "apply manifest secret failed")
 		setStage(StageApply)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha1.ConditionApplied, "ApplyFailed", err.Error())
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionApplied, "ApplyFailed", err.Error())
 	}
-	setCondition(&sm.Status.Conditions, sopsv1alpha1.ConditionApplied, metav1.ConditionTrue, "Applied",
+	setCondition(&sm.Status.Conditions, sopsv1alpha2.ConditionApplied, metav1.ConditionTrue, "Applied",
 		fmt.Sprintf("applied Secret %s/%s", targetNS, targetName))
 
 	sm.Status.LastAppliedHash = hash
-	sm.Status.LastSyncedCommit = commitSHA
+	sm.Status.LastSyncedCommit = revision
+	sm.Status.LastProcessedReconcileToken = sm.Annotations[ReconcileRequestAnnotation]
 	sm.Status.ObservedGeneration = sm.Generation
 	if err := r.Status().Update(ctx, &sm); err != nil {
 		return ctrl.Result{}, err
@@ -164,11 +150,57 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
+func (r *SopsSecretManifestReconciler) fetchManifestSource(ctx context.Context, sm *sopsv1alpha2.SopsSecretManifest) ([]byte, string, *sourceFetchError) {
+	kind := sm.Spec.Source.SourceRef.Kind
+	name := sm.Spec.Source.SourceRef.Name
+	path := sm.Spec.Source.Path
+	srcKey := client.ObjectKey{Namespace: sm.Namespace, Name: name}
+
+	switch kind {
+	case sopsv1alpha2.SourceKindGitRepository:
+		var repo sopsv1alpha1.GitRepository
+		if err := r.Get(ctx, srcKey, &repo); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, "", &sourceFetchError{"SourceMissing", fmt.Sprintf("GitRepository %q not found", name)}
+			}
+			return nil, "", &sourceFetchError{"SourceMissing", err.Error()}
+		}
+		if !isGitSourceReady(&repo) {
+			return nil, "", &sourceFetchError{"SourceNotReady", fmt.Sprintf("GitRepository %q is not ready", name)}
+		}
+		content, sha, err := r.Registry.Read(srcKey, path)
+		if err != nil {
+			return nil, "", &sourceFetchError{"ReadFailed", err.Error()}
+		}
+		return content, sha, nil
+
+	case sopsv1alpha2.SourceKindObjectSource:
+		var os sopsv1alpha2.ObjectSource
+		if err := r.Get(ctx, srcKey, &os); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, "", &sourceFetchError{"SourceMissing", fmt.Sprintf("ObjectSource %q not found", name)}
+			}
+			return nil, "", &sourceFetchError{"SourceMissing", err.Error()}
+		}
+		if !isObjectSourceReady(&os) {
+			return nil, "", &sourceFetchError{"SourceNotReady", fmt.Sprintf("ObjectSource %q is not ready", name)}
+		}
+		content, etag, err := r.Registry.ReadObject(ctx, srcKey, path)
+		if err != nil {
+			return nil, "", &sourceFetchError{"ReadFailed", err.Error()}
+		}
+		return content, etag, nil
+
+	default:
+		return nil, "", &sourceFetchError{"UnknownSourceKind", fmt.Sprintf("unsupported sourceRef.kind %q", kind)}
+	}
+}
+
 func (r *SopsSecretManifestReconciler) applyManifestSecret(
 	ctx context.Context,
-	sm *sopsv1alpha1.SopsSecretManifest,
+	sm *sopsv1alpha2.SopsSecretManifest,
 	parsed *corev1.Secret,
-	name, namespace, hash, commitSHA string,
+	name, namespace, hash, revision string,
 ) error {
 	out := &corev1.Secret{}
 	out.Name = name
@@ -189,8 +221,6 @@ func (r *SopsSecretManifestReconciler) applyManifestSecret(
 			}
 		}
 
-		// Preserve user labels/annotations from the decrypted manifest,
-		// then overlay our ownership markers (ours win on conflict).
 		if out.Labels == nil {
 			out.Labels = map[string]string{}
 		}
@@ -204,13 +234,12 @@ func (r *SopsSecretManifestReconciler) applyManifestSecret(
 		out.Annotations[OwnerAnnotation] = ownerKey
 		out.Annotations[OwnerUIDAnnotation] = string(sm.UID)
 		out.Annotations[ContentHashAnnotation] = hash
-		out.Annotations[SourceCommitAnnotation] = commitSHA
+		out.Annotations[SourceCommitAnnotation] = revision
 
 		out.Type = parsed.Type
 		if out.Type == "" {
 			out.Type = corev1.SecretTypeOpaque
 		}
-		// Data is authoritative — replace wholesale.
 		out.Data = parsed.Data
 		out.StringData = nil
 		return nil
@@ -222,7 +251,7 @@ func (r *SopsSecretManifestReconciler) applyManifestSecret(
 // The decrypted manifest's name is unavailable here, so we either use
 // target.nameOverride if set, or scan managed Secrets in the namespace
 // for the one whose owner annotation matches this CR.
-func (r *SopsSecretManifestReconciler) deleteOwnedSecretIfKnown(ctx context.Context, sm *sopsv1alpha1.SopsSecretManifest) error {
+func (r *SopsSecretManifestReconciler) deleteOwnedSecretIfKnown(ctx context.Context, sm *sopsv1alpha2.SopsSecretManifest) error {
 	ns := sm.Spec.Target.Namespace
 	if ns == "" {
 		ns = sm.Namespace
@@ -264,7 +293,7 @@ func (r *SopsSecretManifestReconciler) deleteIfOwned(ctx context.Context, name, 
 }
 
 func (r *SopsSecretManifestReconciler) failManifestStatus(
-	ctx context.Context, sm *sopsv1alpha1.SopsSecretManifest,
+	ctx context.Context, sm *sopsv1alpha2.SopsSecretManifest,
 	condType, reason, msg string,
 ) (ctrl.Result, error) {
 	setCondition(&sm.Status.Conditions, condType, metav1.ConditionFalse, reason, msg)
@@ -277,28 +306,54 @@ func (r *SopsSecretManifestReconciler) failManifestStatus(
 func (r *SopsSecretManifestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&sopsv1alpha1.SopsSecretManifest{},
-		SopsSecretManifestRepoRefIndex,
+		&sopsv1alpha2.SopsSecretManifest{},
+		SopsSecretManifestGitRefIndex,
 		func(obj client.Object) []string {
-			s := obj.(*sopsv1alpha1.SopsSecretManifest)
-			return []string{s.Spec.Source.RepositoryRef.Name}
+			s := obj.(*sopsv1alpha2.SopsSecretManifest)
+			if s.Spec.Source.SourceRef.Kind != sopsv1alpha2.SourceKindGitRepository {
+				return nil
+			}
+			return []string{s.Spec.Source.SourceRef.Name}
+		},
+	); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&sopsv1alpha2.SopsSecretManifest{},
+		SopsSecretManifestObjectRefIndex,
+		func(obj client.Object) []string {
+			s := obj.(*sopsv1alpha2.SopsSecretManifest)
+			if s.Spec.Source.SourceRef.Kind != sopsv1alpha2.SourceKindObjectSource {
+				return nil
+			}
+			return []string{s.Spec.Source.SourceRef.Name}
 		},
 	); err != nil {
 		return err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&sopsv1alpha1.SopsSecretManifest{}).
-		Watches(&sopsv1alpha1.GitRepository{}, handler.EnqueueRequestsFromMapFunc(r.mapRepoToSopsSecretManifests)).
+		For(&sopsv1alpha2.SopsSecretManifest{}).
+		Watches(&sopsv1alpha1.GitRepository{}, handler.EnqueueRequestsFromMapFunc(r.mapGitRepoToManifests)).
+		Watches(&sopsv1alpha2.ObjectSource{}, handler.EnqueueRequestsFromMapFunc(r.mapObjectSourceToManifests)).
 		Named("sopssecretmanifest").
 		Complete(r)
 }
 
-func (r *SopsSecretManifestReconciler) mapRepoToSopsSecretManifests(ctx context.Context, obj client.Object) []reconcile.Request {
-	var list sopsv1alpha1.SopsSecretManifestList
+func (r *SopsSecretManifestReconciler) mapGitRepoToManifests(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapSourceToManifests(ctx, obj, SopsSecretManifestGitRefIndex)
+}
+
+func (r *SopsSecretManifestReconciler) mapObjectSourceToManifests(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.mapSourceToManifests(ctx, obj, SopsSecretManifestObjectRefIndex)
+}
+
+func (r *SopsSecretManifestReconciler) mapSourceToManifests(ctx context.Context, obj client.Object, index string) []reconcile.Request {
+	var list sopsv1alpha2.SopsSecretManifestList
 	if err := r.List(ctx, &list,
 		client.InNamespace(obj.GetNamespace()),
-		client.MatchingFields{SopsSecretManifestRepoRefIndex: obj.GetName()},
+		client.MatchingFields{index: obj.GetName()},
 	); err != nil {
 		return nil
 	}

--- a/internal/controller/sopssecretmanifest_controller_test.go
+++ b/internal/controller/sopssecretmanifest_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
+	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
 )
 
@@ -40,22 +41,25 @@ var _ = Describe("SopsSecretManifest Controller", func() {
 		uniqueName = func(prefix string) string { return fmt.Sprintf("%s-%d", prefix, counter) }
 	})
 
-	makeCR := func(name, repoRef string) *sopsv1alpha1.SopsSecretManifest {
-		return &sopsv1alpha1.SopsSecretManifest{
+	makeCR := func(name, repoRef string) *sopsv1alpha2.SopsSecretManifest {
+		return &sopsv1alpha2.SopsSecretManifest{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Spec: sopsv1alpha1.SopsSecretManifestSpec{
-				Source: sopsv1alpha1.SourceRef{
-					RepositoryRef: sopsv1alpha1.LocalObjectReference{Name: repoRef},
-					Path:          "secret.enc.yaml",
+			Spec: sopsv1alpha2.SopsSecretManifestSpec{
+				Source: sopsv1alpha2.SourceRef{
+					SourceRef: sopsv1alpha2.SourceKindRef{
+						Kind: sopsv1alpha2.SourceKindGitRepository,
+						Name: repoRef,
+					},
+					Path: "secret.enc.yaml",
 				},
-				Decryption: sopsv1alpha1.DecryptionSpec{
-					KeyRef: sopsv1alpha1.SecretKeyRef{Name: "age-key", Key: "age.agekey"},
+				Decryption: sopsv1alpha2.DecryptionSpec{
+					KeyRef: sopsv1alpha2.SecretKeyRef{Name: "age-key", Key: "age.agekey"},
 				},
 			},
 		}
 	}
 
-	reconcileOnce := func(name string) *sopsv1alpha1.SopsSecretManifest {
+	reconcileOnce := func(name string) *sopsv1alpha2.SopsSecretManifest {
 		r := &SopsSecretManifestReconciler{
 			Client:   k8sClient,
 			Scheme:   k8sClient.Scheme(),
@@ -66,12 +70,12 @@ var _ = Describe("SopsSecretManifest Controller", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		out := &sopsv1alpha1.SopsSecretManifest{}
+		out := &sopsv1alpha2.SopsSecretManifest{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, out)).To(Succeed())
 		return out
 	}
 
-	condition := func(sm *sopsv1alpha1.SopsSecretManifest, t string) *metav1.Condition {
+	condition := func(sm *sopsv1alpha2.SopsSecretManifest, t string) *metav1.Condition {
 		for i := range sm.Status.Conditions {
 			if sm.Status.Conditions[i].Type == t {
 				return &sm.Status.Conditions[i]
@@ -93,7 +97,7 @@ var _ = Describe("SopsSecretManifest Controller", func() {
 				NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
 			})
 
-			got := &sopsv1alpha1.SopsSecretManifest{}
+			got := &sopsv1alpha2.SopsSecretManifest{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, got)).To(Succeed())
 			Expect(got.Finalizers).To(ContainElement(Finalizer))
 
@@ -106,10 +110,10 @@ var _ = Describe("SopsSecretManifest Controller", func() {
 			name := uniqueName("sm-no-repo")
 			Expect(k8sClient.Create(ctx, makeCR(name, "missing-repo"))).To(Succeed())
 
-			_ = reconcileOnce(name) // finalizer add
+			_ = reconcileOnce(name)
 			got := reconcileOnce(name)
 
-			c := condition(got, sopsv1alpha1.ConditionSourceReady)
+			c := condition(got, sopsv1alpha2.ConditionSourceReady)
 			Expect(c).NotTo(BeNil())
 			Expect(c.Status).To(Equal(metav1.ConditionFalse))
 			Expect(c.Reason).To(Equal("SourceMissing"))
@@ -130,7 +134,7 @@ var _ = Describe("SopsSecretManifest Controller", func() {
 			_ = reconcileOnce(name)
 			got := reconcileOnce(name)
 
-			c := condition(got, sopsv1alpha1.ConditionSourceReady)
+			c := condition(got, sopsv1alpha2.ConditionSourceReady)
 			Expect(c).NotTo(BeNil())
 			Expect(c.Status).To(Equal(metav1.ConditionFalse))
 			Expect(c.Reason).To(Equal("SourceNotReady"))

--- a/internal/keyresolve/age.go
+++ b/internal/keyresolve/age.go
@@ -9,14 +9,19 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
 )
+
+// SecretKeyRef is a neutral pair of (Secret name, data key) used to fetch
+// an age private key. Decoupled from any API version's Go type.
+type SecretKeyRef struct {
+	Name string
+	Key  string
+}
 
 // Age reads the age private key bytes from the named Secret+key in the
 // given namespace. Returns an error if the Secret or key is missing, or
 // if the key value is empty.
-func Age(ctx context.Context, c client.Client, namespace string, ref sopsv1alpha1.SecretKeyRef) ([]byte, error) {
+func Age(ctx context.Context, c client.Client, namespace string, ref SecretKeyRef) ([]byte, error) {
 	var sec corev1.Secret
 	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, &sec); err != nil {
 		return nil, fmt.Errorf("get age-key secret %q: %w", ref.Name, err)

--- a/internal/transform/flat.go
+++ b/internal/transform/flat.go
@@ -12,9 +12,15 @@ import (
 	"strconv"
 
 	"sigs.k8s.io/yaml"
-
-	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
 )
+
+// DataMapping is the neutral representation of a (target Secret key, source
+// flat-YAML key) pair. Decoupled from any API version's Go type so this
+// package does not import the api/ tree.
+type DataMapping struct {
+	Key  string
+	From string
+}
 
 // ParseFlatYAML unmarshals plaintext as a top-level map of scalars.
 // Returns an error if any top-level value is not a scalar — this is the
@@ -65,7 +71,7 @@ func scalarToString(v any) (string, error) {
 
 // ApplyMapping selects and renames keys according to the CR's Data slice.
 // Fails closed when any mapped source key is missing.
-func ApplyMapping(source map[string]string, mappings []sopsv1alpha1.DataMapping) (map[string][]byte, error) {
+func ApplyMapping(source map[string]string, mappings []DataMapping) (map[string][]byte, error) {
 	out := make(map[string][]byte, len(mappings))
 	for _, m := range mappings {
 		val, ok := source[m.From]

--- a/internal/transform/flat_test.go
+++ b/internal/transform/flat_test.go
@@ -3,8 +3,6 @@ package transform
 import (
 	"strings"
 	"testing"
-
-	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
 )
 
 func TestParseFlatYAML(t *testing.T) {
@@ -59,7 +57,7 @@ func TestParseFlatYAMLRejectsNull(t *testing.T) {
 
 func TestApplyMappingFailClosed(t *testing.T) {
 	src := map[string]string{"a": "1"}
-	_, err := ApplyMapping(src, []sopsv1alpha1.DataMapping{{Key: "X", From: "missing"}})
+	_, err := ApplyMapping(src, []DataMapping{{Key: "X", From: "missing"}})
 	if err == nil || !strings.Contains(err.Error(), "missing") {
 		t.Fatalf("expected missing-key error, got %v", err)
 	}
@@ -67,7 +65,7 @@ func TestApplyMappingFailClosed(t *testing.T) {
 
 func TestApplyMappingRenames(t *testing.T) {
 	src := map[string]string{"db_user": "alice", "db_pass": "s3cret"}
-	out, err := ApplyMapping(src, []sopsv1alpha1.DataMapping{
+	out, err := ApplyMapping(src, []DataMapping{
 		{Key: "DB_USER", From: "db_user"},
 		{Key: "DB_PASSWORD", From: "db_pass"},
 	})


### PR DESCRIPTION
## Summary

Closes Stage C of #12 (#26) and adds the force-sync annotation handler (#23). Bundled because both touch the SopsSecret/SopsSecretManifest controllers, which were rewritten on v1alpha2 as part of the dispatch refactor — splitting the \`LastProcessedReconcileToken\` field/logic into a separate PR would require a transitional duplicate of those controllers.

## Stage C (#26) — sourceRef dispatch + conversion webhook

- \`SopsSecret\` + \`SopsSecretManifest\` now reconcile against the v1alpha2 hub and branch on \`spec.source.sourceRef.kind\`:
  - \`GitRepository\` → \`Registry.Read\`
  - \`ObjectSource\` → \`Registry.ReadObject\`
- Two indexers + two \`Watches()\` per consumer; \`mapSource{Git,Object}…\` enqueue dependents on either source kind's status changes.
- Storage version flipped to v1alpha2 for \`SopsSecret\` + \`SopsSecretManifest\` (non-isomorphic schema vs v1alpha1). \`GitRepository\` / \`InlineSopsSecret\` stay v1alpha1 — schemas are isomorphic, default conversion strategy=None is fine.
- Conversion-webhook deployment scaffolding:
  - \`config/crd/patches/webhook_in_{sopssecrets,sopssecretmanifests}.yaml\` — patch the two CRDs whose schemas changed to \`strategy: Webhook\`.
  - \`config/webhook/service.yaml\` — Service backs the controller-runtime auto-registered \`/convert\` handler.
  - \`config/default/kustomization.yaml\` now pulls \`../webhook\`. Cert-manager wiring left as scaffold-only.
- New \`internal/controller/objectsourced_happypath_test.go\` mirrors \`gitsourced_happypath_test.go\` — mapping mode, manifest mode, drift revert, force-sync — backed by \`httptest.Server\`.

## Force-sync (#23)

- New annotation \`sops.stuttgart-things.com/reconcile-requested\`. When its value differs from \`status.lastProcessedReconcileToken\`, the next reconcile runs the full pipeline and the token is written back on success.
- **Source CRs** (\`GitRepository\`, \`ObjectSource\`): reconciler drops the cached entry before the next \`EnsureCached\` / \`EnsureObjectCached\` call, forcing an unconditional re-fetch (regardless of commit/ETag).
- **Consumer CRs** (\`SopsSecret\`, \`SopsSecretManifest\`, \`InlineSopsSecret\`): the pipeline already re-reads cached content + re-applies on every reconcile, so the only behavior is recording the honored token. To force a fresh upstream fetch, annotate the source CR.
- Status field added to all five CR kinds (both API versions where applicable; conversion functions round-trip it).

## Refactors

- \`internal/keyresolve\` and \`internal/transform\` decoupled from the \`api/\` tree (now use neutral local types for \`SecretKeyRef\` / \`DataMapping\`). Lets the v1alpha2 consumer controllers call them directly without round-tripping through v1alpha1 structs.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./... \` clean (all 39 envtest specs pass; conversion roundtrip unit tests pass)
- [x] \`make manifests && make generate\` regenerated CRDs + deepcopy with no diff drift
- [x] \`kustomize build config/default\` renders the conversion webhook config with the correct service name (\`sops-secrets-operator-webhook-service\`) injected via namePrefix
- [ ] Real-cluster smoke test of v1alpha1 → v1alpha2 conversion via the webhook (covered by Stage C acceptance criteria; deferred to a follow-up real-cluster e2e PR per the Stage C scope notes)

Closes #26
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)