### PR TITLE
feat(deploy): cert-manager wiring + real-cluster e2e for conversion webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,11 @@ The reconciler compares the annotation value to `status.lastProcessedReconcileTo
 
 ## v1alpha1 backward compatibility
 
-`SopsSecret` and `SopsSecretManifest` switched their stored shape between v1alpha1 (`source.repositoryRef.name`) and v1alpha2 (`source.sourceRef.{kind,name}`). The CRDs declare `spec.conversion.strategy: Webhook` so v1alpha1 manifests still apply through the operator's auto-registered `/convert` handler — but the apiserver needs to trust the webhook's TLS cert. The default install ships the webhook `Service` (`config/webhook/`); cert-manager wiring is scaffold-only. Until you wire cert-manager (or provision certs another way), prefer v1alpha2 manifests, which match the storage version and don't trigger conversion.
+`SopsSecret` and `SopsSecretManifest` switched their stored shape between v1alpha1 (`source.repositoryRef.name`) and v1alpha2 (`source.sourceRef.{kind,name}`). The CRDs declare `spec.conversion.strategy: Webhook` so v1alpha1 manifests still apply through the operator's auto-registered `/convert` handler.
+
+The default install (`kubectl apply -k config/default`) wires this end-to-end via cert-manager: an `Issuer` + `Certificate` in `config/certmanager/` issues the webhook serving cert into `webhook-server-cert`, and kustomize replacements stamp the `cert-manager.io/inject-ca-from` annotation onto both CRDs so the apiserver picks up the CA bundle. **cert-manager must be installed in the cluster** before applying the bundle (`kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml`).
+
+If you cannot run cert-manager, either provision the webhook cert externally and patch the CRDs' `spec.conversion.webhook.clientConfig.caBundle` yourself, or stick to v1alpha2 manifests (which match the storage version and never go through `/convert`).
 
 ## Security model
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	sopsv1alpha1 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha1"
 	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
@@ -223,6 +224,11 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	// Register the conversion webhook for the v1alpha1 ↔ v1alpha2 hub.
+	// Without this the webhook Server starts but /convert is unhandled,
+	// so the apiserver gets connection refused when admitting v1alpha1 CRs.
+	mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(mgr.GetScheme(), conversion.NewRegistry()))
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up health check")

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,34 @@
+# Self-signed Issuer + Certificate that backs the conversion webhook's
+# TLS. The Certificate's dnsNames are populated by the
+# CONVERSIONWEBHOOK replacements block in config/default/kustomization.yaml
+# so the names always track namePrefix and namespace.
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+  labels:
+    app.kubernetes.io/name: sops-secrets-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+  namespace: system
+  labels:
+    app.kubernetes.io/name: sops-secrets-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE are populated via kustomize
+  # replacements that read from the webhook Service in config/webhook.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,9 @@
+# Tell kustomize not to mangle cert-manager.io references when
+# resolving CA-injection annotations.
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/config/crd/patches/webhook_in_sopssecretmanifests.yaml
+++ b/config/crd/patches/webhook_in_sopssecretmanifests.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: sopssecretmanifests.sops.stuttgart-things.com
 spec:
   conversion:

--- a/config/crd/patches/webhook_in_sopssecrets.yaml
+++ b/config/crd/patches/webhook_in_sopssecrets.yaml
@@ -3,9 +3,15 @@
 # webhook is required to lossfully convert between them. The operator's
 # controller-runtime webhook server registers /convert automatically for
 # any scheme-registered type that implements Hub() / ConvertTo / ConvertFrom.
+#
+# The cert-manager.io/inject-ca-from annotation is populated by kustomize
+# replacements in config/default/kustomization.yaml so the CA bundle in
+# the conversion webhook clientConfig stays in sync with the cert.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: sopssecrets.sops.stuttgart-things.com
 spec:
   conversion:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,8 +23,10 @@ resources:
 # wiring is still scaffold-only — uncomment ../certmanager and the
 # CONVERSIONWEBHOOK replacements below to issue real serving certs.
 - ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+# [CERTMANAGER] cert-manager issues the conversion-webhook serving cert and
+# injects the CA bundle into the SopsSecret / SopsSecretManifest CRDs via
+# the inject-ca-from annotation. Required for v1alpha1 CRs to convert.
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -50,187 +52,109 @@ patches:
 #  target:
 #    kind: Deployment
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
-#  target:
-#    kind: Deployment
+# [WEBHOOK] Mount the cert-manager-issued webhook serving cert into the
+# manager Pod and set --webhook-cert-path so the conversion webhook serves TLS.
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
-# - source: # Uncomment the following block to enable certificates for metrics
-#     kind: Service
-#     version: v1
-#     name: controller-manager-metrics-service
-#     fieldPath: metadata.name
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: metrics-certs
-#       fieldPaths:
-#         - spec.dnsNames.0
-#         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
-#     - select: # Uncomment the following to set the Service name for TLS config in Prometheus ServiceMonitor
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
+# [CERTMANAGER] Replacements that wire the cert-manager Certificate to:
+#   1. the webhook Service DNS names (so the cert is valid for the in-cluster service);
+#   2. the SopsSecret / SopsSecretManifest CRDs' cert-manager.io/inject-ca-from
+#      annotation (so the apiserver trusts the conversion-webhook TLS).
+replacements:
+# Webhook Service name → Certificate dnsNames[0..1] (host part).
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+        name: serving-cert
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+# Webhook Service namespace → Certificate dnsNames[0..1] (namespace part).
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+        name: serving-cert
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true
 
-# - source:
-#     kind: Service
-#     version: v1
-#     name: controller-manager-metrics-service
-#     fieldPath: metadata.namespace
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: metrics-certs
-#       fieldPaths:
-#         - spec.dnsNames.0
-#         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select: # Uncomment the following to set the Service namespace for TLS in Prometheus ServiceMonitor
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-
-# - source: # Uncomment the following block if you have any webhook
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.name # Name of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.namespace # Namespace of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-
-# - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # This name should match the one in certificate.yaml
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: ValidatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: ValidatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
-
-# - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: MutatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: MutatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
-
-# - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
-# +kubebuilder:scaffold:crdkustomizecainjectionns
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
-# +kubebuilder:scaffold:crdkustomizecainjectionname
+# ConversionWebhook: Certificate namespace → CRDs' inject-ca-from (ns part).
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.namespace
+  targets:
+    - select:
+        kind: CustomResourceDefinition
+        name: sopssecrets.sops.stuttgart-things.com
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+        name: sopssecretmanifests.sops.stuttgart-things.com
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    # Do not remove the following scaffold marker; required to generate code for target CRD.
+    # +kubebuilder:scaffold:crdkustomizecainjectionns
+# ConversionWebhook: Certificate name → CRDs' inject-ca-from (name part).
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: CustomResourceDefinition
+        name: sopssecrets.sops.stuttgart-things.com
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+        name: sopssecretmanifests.sops.stuttgart-things.com
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    # Do not remove the following scaffold marker; required to generate code for target CRD.
+    # +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,21 @@
+# Mount the conversion-webhook serving cert (issued by cert-manager into
+# the webhook-server-cert Secret) and tell the manager to use it.
+
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: webhook-certs
+    readOnly: true
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: webhook-certs
+    secret:
+      secretName: webhook-server-cert
+      optional: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
           type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - sops-secrets-operator
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package e2e
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -269,6 +270,144 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
+
+		It("should round-trip a v1alpha1 SopsSecret through the conversion webhook to v1alpha2 storage", func() {
+			const conversionNs = "e2e-conversion"
+			By("creating a namespace for the conversion test")
+			cmd := exec.Command("kubectl", "create", "ns", conversionNs)
+			_, _ = utils.Run(cmd)
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "ns", conversionNs, "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
+
+			// The CR references a GitRepository that does not exist; the
+			// reconciler will surface a not-ready condition, but conversion
+			// happens at admission time and is what we are asserting here.
+			manifest := `---
+apiVersion: sops.stuttgart-things.com/v1alpha1
+kind: SopsSecret
+metadata:
+  name: conversion-probe
+  namespace: e2e-conversion
+spec:
+  source:
+    repositoryRef:
+      name: nonexistent-repo
+    path: prod/app/creds.enc.yaml
+  decryption:
+    keyRef:
+      name: dummy-age-key
+      key: age.agekey
+  data:
+    - key: DATABASE_URL
+      from: database_url
+`
+			By("applying the v1alpha1 SopsSecret (admission goes through the conversion webhook)")
+			out, err := kubectlApply(manifest)
+			Expect(err).NotTo(HaveOccurred(), "kubectl apply output: %s", out)
+
+			By("reading the same CR via the v1alpha2 endpoint to confirm sourceRef was populated by ConvertTo")
+			verifyConverted := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"sopssecrets.v1alpha2.sops.stuttgart-things.com", "conversion-probe",
+					"-n", conversionNs,
+					"-o", "jsonpath={.spec.source.sourceRef.kind}/{.spec.source.sourceRef.name}",
+				)
+				kind, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(kind).To(Equal("GitRepository/nonexistent-repo"))
+			}
+			Eventually(verifyConverted, 30*time.Second).Should(Succeed())
+		})
+
+		It("should reconcile a v1alpha2 SopsSecret backed by an ObjectSource", func() {
+			const objNs = "e2e-objectsource"
+
+			By("creating the test namespace")
+			cmd := exec.Command("kubectl", "create", "ns", objNs)
+			_, _ = utils.Run(cmd)
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "ns", objNs, "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
+
+			By("generating a fresh age identity and a SOPS-encrypted YAML payload")
+			fixture := newE2EAge(GinkgoT())
+
+			By("deploying an in-cluster nginx Pod + Service that serves the encrypted YAML")
+			nginxYAML := nginxFixtureManifest(objNs, "encrypted-source", "shared.enc.yaml", fixture.Ciphertext)
+			out, err := kubectlApply(nginxYAML)
+			Expect(err).NotTo(HaveOccurred(), "kubectl apply nginx fixture: %s", out)
+
+			By("waiting for the nginx Pod to be Ready")
+			cmd = exec.Command("kubectl", "wait", "--for=condition=Ready",
+				"pod/encrypted-source", "-n", objNs, "--timeout=2m")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "nginx Pod did not become Ready")
+
+			By("creating the age private-key Secret")
+			out, err = kubectlApply(ageKeySecretManifest(objNs, "sops-age-key", fixture.Key.PrivateKey))
+			Expect(err).NotTo(HaveOccurred(), "kubectl apply age key: %s", out)
+
+			By("creating the ObjectSource")
+			objectSrcURL := fmt.Sprintf("http://encrypted-source.%s.svc:80/shared.enc.yaml", objNs)
+			objectSrc := fmt.Sprintf(`---
+apiVersion: sops.stuttgart-things.com/v1alpha2
+kind: ObjectSource
+metadata:
+  name: shared-secrets-https
+  namespace: %s
+spec:
+  url: %s
+  auth:
+    type: none
+`, objNs, objectSrcURL)
+			out, err = kubectlApply(objectSrc)
+			Expect(err).NotTo(HaveOccurred(), "kubectl apply ObjectSource: %s", out)
+
+			By("creating the v1alpha2 SopsSecret that consumes the ObjectSource")
+			sopsSecret := fmt.Sprintf(`---
+apiVersion: sops.stuttgart-things.com/v1alpha2
+kind: SopsSecret
+metadata:
+  name: app-creds-https
+  namespace: %s
+spec:
+  source:
+    sourceRef:
+      kind: ObjectSource
+      name: shared-secrets-https
+    path: shared.enc.yaml
+  decryption:
+    keyRef:
+      name: sops-age-key
+      key: age.agekey
+  data:
+    - key: DATABASE_URL
+      from: database_url
+    - key: API_TOKEN
+      from: api_token
+`, objNs)
+			out, err = kubectlApply(sopsSecret)
+			Expect(err).NotTo(HaveOccurred(), "kubectl apply SopsSecret: %s", out)
+
+			By("waiting for the target Secret to be reconciled with the decrypted values")
+			verifyTargetSecret := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secret", "app-creds-https",
+					"-n", objNs,
+					"-o", "jsonpath={.data.DATABASE_URL}/{.data.API_TOKEN}",
+				)
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).NotTo(BeEmpty())
+
+				expectedURL := base64.StdEncoding.EncodeToString([]byte("postgres://app@db:5432/app"))
+				expectedTok := base64.StdEncoding.EncodeToString([]byte("e2e-token-xyz"))
+				g.Expect(out).To(Equal(expectedURL + "/" + expectedTok))
+			}
+			Eventually(verifyTargetSecret, 3*time.Minute, 2*time.Second).Should(Succeed())
+		})
 
 		// TODO: Customize the e2e test suite with scenarios specific to your project.
 		// Consider applying sample/CR(s) and check their status and/or verifying

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -1,0 +1,131 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package e2e
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/stuttgart-things/sops-secrets-operator/internal/testutil"
+	"github.com/stuttgart-things/sops-secrets-operator/test/utils"
+)
+
+// kubectlApply pipes a YAML document to `kubectl apply -f -`.
+func kubectlApply(manifest string) (string, error) {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	return utils.Run(cmd)
+}
+
+// kubectlDelete is the cleanup counterpart for kubectlApply. Errors are
+// swallowed because deletes during teardown are best-effort.
+func kubectlDelete(manifest string) {
+	cmd := exec.Command("kubectl", "delete", "--ignore-not-found", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	_, _ = utils.Run(cmd)
+}
+
+// e2eAge wraps a generated age identity together with an encrypted YAML
+// payload encoded against that identity's recipient.
+type e2eAge struct {
+	Key        testutil.AgeKey
+	Plaintext  []byte
+	Ciphertext []byte
+}
+
+// newE2EAge returns a fresh age identity and a SOPS-encrypted YAML doc
+// keyed to it. The plaintext carries two well-known fields so reconcile
+// assertions can pin exact values.
+func newE2EAge(tb testutil.TestingT) e2eAge {
+	tb.Helper()
+	key := testutil.GenerateAge(tb)
+	plaintext := []byte("database_url: postgres://app@db:5432/app\napi_token: e2e-token-xyz\n")
+	ct := testutil.EncryptYAML(tb, key.PublicKey, plaintext)
+	return e2eAge{Key: key, Plaintext: plaintext, Ciphertext: ct}
+}
+
+// ageKeySecretManifest returns the YAML for a k8s Secret carrying the
+// age private key under the `age.agekey` field. The private key is
+// indented under a YAML block scalar so embedded newlines (none today,
+// but possible in multi-line keys) survive.
+func ageKeySecretManifest(namespace, name, privateKey string) string {
+	return fmt.Sprintf(`---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+type: Opaque
+stringData:
+  age.agekey: %q
+`, name, namespace, privateKey)
+}
+
+// nginxFixtureManifest returns a Pod + Service that serves `content` at
+// http://<name>.<namespace>.svc:80/<filename>. The content is delivered
+// via a ConfigMap.binaryData (base64) so SOPS YAML — which contains
+// literal newlines and quote chars that complicate YAML string escaping —
+// round-trips byte-for-byte to the file.
+func nginxFixtureManifest(namespace, name, filename string, content []byte) string {
+	encoded := base64.StdEncoding.EncodeToString(content)
+	return fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s-content
+  namespace: %s
+binaryData:
+  %s: %s
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: %s
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.27-alpine
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - name: content
+      mountPath: /usr/share/nginx/html
+      readOnly: true
+  volumes:
+  - name: content
+    configMap:
+      name: %s-content
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  selector:
+    app: %s
+  ports:
+  - port: 80
+    targetPort: 80
+`, name, namespace, filename, encoded,
+		name, namespace, name,
+		name,
+		name, namespace, name)
+}
+


### PR DESCRIPTION
## Summary
- **cert-manager is the default path for the conversion-webhook TLS.** `kubectl apply -k config/default` now ships an Issuer + Certificate (`config/certmanager/`), mounts the resulting `webhook-server-cert` Secret into the manager Pod (new `manager_webhook_patch.yaml` + `--webhook-cert-path` arg), and uses kustomize replacements to stamp `cert-manager.io/inject-ca-from` onto both `SopsSecret` and `SopsSecretManifest` CRDs. Without this, v1alpha1 CRs failed conversion on a default install (PR #30 left it scaffold-only).
- **Two real-cluster e2e specs** under build tag `e2e`:
  - **v1alpha1 → v1alpha2 conversion roundtrip** — apply a v1alpha1 `SopsSecret` and assert it stores as v1alpha2 with `sourceRef.{kind,name}` populated by `ConvertTo`.
  - **ObjectSource end-to-end** — generate a fresh age identity at test time, encrypt a YAML payload via `internal/testutil.EncryptYAML`, deploy an in-cluster nginx Pod + Service that serves it from a `ConfigMap.binaryData`, point an `ObjectSource` + v1alpha2 `SopsSecret` at the URL, and assert the target `Secret` materialises with the decrypted values.
- README's v1alpha1 backward-compat caveat is reworded — cert-manager is documented as a prereq, with an opt-out fallback for non-cert-manager clusters.

## Bonus fixes (pre-existing v0.6.0 install-blockers, surfaced by the new e2e)
Both shipped in v0.6.0; neither was reachable from envtest. Without them, no real-cluster install of v0.6.0 could possibly have worked end-to-end:
- **`fix(deploy)`** — `config/manager/manager.yaml` had `command: [/manager]` but the project Dockerfile installs the binary at `/usr/local/bin/sops-secrets-operator`. Pod crash-looped with `exec: "/manager": no such file or directory`. Changed `command` to `sops-secrets-operator`.
- **`fix(webhook)`** — PR #30 added `Hub` / `ConvertTo` / `ConvertFrom` on the API types but never registered `/convert` with `mgr.GetWebhookServer()`. Webhook server started, cert mounted, but no handler bound; apiserver got connection refused on every v1alpha1 admission. Wired `conversion.NewWebhookHandler(scheme, registry)` into the manager's webhook server.

Closes #32.

## Test plan
- [x] `go test ./...` — full unit + envtest suite green.
- [x] `kustomize build config/default` produces (a) `Issuer` + `Certificate`, (b) both CRDs annotated with `cert-manager.io/inject-ca-from: <ns>/<cert>`, (c) manager Pod with `webhook-certs` volume + `--webhook-cert-path` arg.
- [x] `make test-e2e` on a Kind cluster — auto-installs cert-manager, **all 4 specs pass** (controller-up, metrics, conversion roundtrip, ObjectSource reconcile end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)