### PR TITLE
test: verify e2e gate catches regressions (DO NOT MERGE)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -225,10 +225,11 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	// Register the conversion webhook for the v1alpha1 ↔ v1alpha2 hub.
-	// Without this the webhook Server starts but /convert is unhandled,
-	// so the apiserver gets connection refused when admitting v1alpha1 CRs.
-	mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(mgr.GetScheme(), conversion.NewRegistry()))
+	// DELIBERATELY BROKEN — this branch verifies CI e2e catches regressions.
+	// The conversion-webhook registration below is commented out so /convert
+	// returns connection-refused for v1alpha1 admissions. DO NOT MERGE.
+	// mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(mgr.GetScheme(), conversion.NewRegistry()))
+	_ = conversion.NewRegistry
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up health check")


### PR DESCRIPTION
## Purpose

Confirms acceptance criterion #3 of #34: *"a deliberately-broken PR reproduces a red e2e job."* This is a throwaway PR — will be closed and branch deleted as soon as CI shows the expected red.

## What's broken

`cmd/main.go` has the `/convert` registration for the v1alpha1 ↔ v1alpha2 conversion webhook commented out. This is the exact regression PR #33 fixed. The conversion-roundtrip spec in `test/e2e/e2e_test.go` should fail at apiserver-admission time with connection-refused on `/convert`.

## Expected outcome

- `build-test.yaml` (envtest): green — envtest doesn't run conversion webhooks.
- `e2e.yaml`: red — the v1alpha1↔v1alpha2 conversion roundtrip spec should fail.

If e2e goes green here, the gate isn't actually catching this class of regression and we need to fix it before flipping branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)