### PR TITLE
fix(e2e): drain CRs before make undeploy so finalizers strip cleanly (closes #36)

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -78,31 +78,40 @@ var _ = Describe("Manager", Ordered, func() {
 	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
 	// and deleting the namespace.
 	AfterAll(func() {
-		// Bound every cluster-side teardown command with the OS `timeout`
-		// utility. A stuck finalizer (controller deleted before it can
-		// drain a leftover CR) makes both `kubectl delete` and its
-		// `--timeout=` flag unreliable — apiserver can be reachable yet
-		// the resource never finalizes. Errors are ignored: the kind
-		// cluster is destroyed by `make cleanup-test-e2e` immediately
-		// after the suite, so partial teardown is acceptable.
 		By("cleaning up the curl pod for metrics")
-		cmd := exec.Command("timeout", "--kill-after=5", "30",
-			"kubectl", "delete", "pod", "curl-metrics", "-n", namespace,
-			"--ignore-not-found", "--wait=false")
+		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics",
+			"-n", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 
+		// Drain every operator-managed CR across all namespaces *before*
+		// the controller goes away. If `make uninstall` deletes the CRDs
+		// first, the apiserver garbage-collects every CR — but the
+		// controller is already gone, no one strips the finalizer, and
+		// the CRDs stay Terminating waiting for it. With the controller
+		// still alive here, the finalizers run cleanly.
+		By("draining operator-managed CRs while the controller is still alive")
+		for _, kind := range []string{
+			"sopssecrets.sops.stuttgart-things.com",
+			"sopssecretmanifests.sops.stuttgart-things.com",
+			"inlinesopssecrets.sops.stuttgart-things.com",
+			"gitrepositories.sops.stuttgart-things.com",
+			"objectsources.sops.stuttgart-things.com",
+		} {
+			cmd = exec.Command("kubectl", "delete", kind, "--all",
+				"--all-namespaces", "--ignore-not-found", "--timeout=30s")
+			_, _ = utils.Run(cmd)
+		}
+
 		By("undeploying the controller-manager")
-		cmd = exec.Command("timeout", "--kill-after=5", "60", "make", "undeploy", "ignore-not-found=true")
+		cmd = exec.Command("make", "undeploy", "ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
 		By("uninstalling CRDs")
-		cmd = exec.Command("timeout", "--kill-after=5", "60", "make", "uninstall", "ignore-not-found=true")
+		cmd = exec.Command("make", "uninstall", "ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
 		By("removing manager namespace")
-		cmd = exec.Command("timeout", "--kill-after=5", "30",
-			"kubectl", "delete", "ns", namespace,
-			"--ignore-not-found", "--wait=false")
+		cmd = exec.Command("kubectl", "delete", "ns", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
 	})
 


### PR DESCRIPTION
## Summary

- Drain all 5 operator-managed CR kinds across all namespaces at the start of `AfterAll`, while the controller is still alive to strip finalizers.
- Then `make undeploy` (controller goes away) → `make uninstall` (CRD GC is now instant — no leftover CRs) → `kubectl delete ns`.
- Removed the `timeout --kill-after=5 N` wrappers and `--wait=false` flags from PR #35 (those were band-aids; they capped the damage but masked the ordering bug).

## Why

The hang in #36 was an ordering bug. `make undeploy` deleted the controller Pod *before* `make uninstall` deleted the CRDs. CRD deletion garbage-collects every CR, but each CR carries an operator finalizer — and the controller (the only thing that strips them) was already gone, so CRs stayed Terminating, CRDs stayed Terminating, `kubectl delete -f -` waited forever. Draining CRs first means finalizers run while there's still someone home to run them.

## Test plan

- [x] `go vet -tags=e2e ./test/e2e/...` clean
- [x] Local `make test-e2e` green: 4 Passed | 0 Failed | 0 Skipped, suite total 113.88s
- [x] Cluster-side teardown wall-clock: ~13s (curl pod 0.1s → drain CRs 0.8s → `make undeploy` 9.1s → `make uninstall` 2.9s → ns delete + AfterSuite). Well under the 90s acceptance from #36.
- [ ] CI e2e job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)