### PR TITLE
fix(e2e): clean up metrics ClusterRoleBinding in AfterAll

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -113,6 +113,15 @@ var _ = Describe("Manager", Ordered, func() {
 		By("removing manager namespace")
 		cmd = exec.Command("kubectl", "delete", "ns", namespace, "--ignore-not-found")
 		_, _ = utils.Run(cmd)
+
+		// Cluster-scoped, so the namespace delete above won't remove it.
+		// Without this, the metrics-endpoint spec's `kubectl create` errors
+		// with "already exists" on the next run on a self-hosted runner
+		// that reuses the kind cluster.
+		By("removing metrics ClusterRoleBinding")
+		cmd = exec.Command("kubectl", "delete", "clusterrolebinding",
+			metricsRoleBindingName, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
 	})
 
 	// After each test, check for failures and collect logs, events,
@@ -196,10 +205,15 @@ var _ = Describe("Manager", Ordered, func() {
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=sops-secrets-operator-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
+			// Idempotent apply rather than bare `create`: a previous failed run on
+			// a self-hosted runner can leave the CRB behind and `kubectl create`
+			// would error with "already exists".
+			cmd := exec.Command("sh", "-c", fmt.Sprintf(
+				"kubectl create clusterrolebinding %s "+
+					"--clusterrole=sops-secrets-operator-metrics-reader "+
+					"--serviceaccount=%s:%s --dry-run=client -o yaml | kubectl apply -f -",
+				metricsRoleBindingName, namespace, serviceAccountName,
+			))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
 


### PR DESCRIPTION
## Summary

Closes #41.

Two related fixes for the metrics-endpoint spec when run on a self-hosted runner that reuses the kind cluster between runs:

- **AfterAll**: delete the metrics ClusterRoleBinding. It's cluster-scoped, so the namespace delete doesn't reach it. Without this, the next run trips on `clusterrolebindings.rbac.authorization.k8s.io "sops-secrets-operator-metrics-binding" already exists`.
- **Spec**: replace bare `kubectl create clusterrolebinding ...` with a `--dry-run=client | kubectl apply -f -` pipeline. Defensive: a leftover CRB from any past failed run (including pre-this-PR runs that never reached AfterAll) is upgraded in place rather than rejected.

## Why now

Surfaced on a CI run after PR #38 merged. PR #38 fixed the *finalizer* class of teardown hang but didn't touch the cluster-scoped CRB the metrics spec creates — that was a separate latent leak from the original e2e suite (PR #33). Same theme as #36; this is the next layer.

## Test plan

- [x] `go vet -tags=e2e ./test/e2e/...` clean
- [ ] CI e2e job green — the failing run was 25040397485; this PR's run should reproduce-then-pass since the AfterAll cleanup runs after the spec succeeds, leaving a clean cluster for the next PR
- [ ] Subsequent PR's e2e job green (proves the leak is actually closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)