### PR TITLE
ci(e2e): switch to dedicated kind-test runner + harden Makefile (closes #43)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,12 @@ concurrency:
 jobs:
   e2e:
     name: e2e (kind + cert-manager)
-    runs-on: dagger-labda
+    # Dedicated kind-only runner provisioned in #43. Two runners exist
+    # (kind-testing-runner-1, kind-testing-runner-2); pick one with a
+    # `runs-on` array fallback. With `concurrency: cancel-in-progress`
+    # set above only one job runs at a time anyway, so the second runner
+    # is hot-spare / room for a sibling project.
+    runs-on: [self-hosted, kind-testing-runner-1]
     timeout-minutes: 40
     permissions:
       contents: read
@@ -48,9 +53,30 @@ jobs:
       - name: Scrub leftover kind cluster
         run: kind delete cluster --name sops-secrets-operator-test-e2e || true
 
+      - name: Pre-run diagnostics
+        run: |
+          echo "=== docker ps -a ==="
+          docker ps -a || true
+          echo "=== free -h ==="
+          free -h || true
+          echo "=== df -h /var/lib/docker / ==="
+          df -h /var/lib/docker / || true
+
       - name: Run e2e
         run: make test-e2e
 
       - name: Cleanup kind cluster
         if: always()
         run: kind delete cluster --name sops-secrets-operator-test-e2e || true
+
+      - name: Post-run diagnostics (on failure only)
+        if: failure()
+        run: |
+          echo "=== docker ps -a ==="
+          docker ps -a || true
+          echo "=== free -h ==="
+          free -h || true
+          echo "=== df -h /var/lib/docker / ==="
+          df -h /var/lib/docker / || true
+          echo "=== last 200 lines of dockerd journal ==="
+          journalctl -u docker --no-pager -n 200 || true

--- a/Makefile
+++ b/Makefile
@@ -68,23 +68,28 @@ test: manifests generate fmt vet setup-envtest ## Run tests under -race.
 KIND_CLUSTER ?= sops-secrets-operator-test-e2e
 
 .PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
+setup-test-e2e: ## Tear down any existing Kind cluster and create a fresh one for e2e tests
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
 	}
-	@case "$$($(KIND) get clusters)" in \
-		*"$(KIND_CLUSTER)"*) \
-			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
-		*) \
-			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
-	esac
+	@# Always start from a clean slate. The previous "skip if exists"
+	@# branch made local re-runs faster but let leftover state from a
+	@# prior failed run poison the next attempt — a recurring source of
+	@# flake on self-hosted runners (#43).
+	@echo "Tearing down any existing Kind cluster '$(KIND_CLUSTER)'..."
+	@$(KIND) delete cluster --name $(KIND_CLUSTER) >/dev/null 2>&1 || true
+	@echo "Creating Kind cluster '$(KIND_CLUSTER)'..."
+	@$(KIND) create cluster --name $(KIND_CLUSTER)
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e -timeout=30m ./test/e2e/ -v -ginkgo.v
-	$(MAKE) cleanup-test-e2e
+	@# `trap` ensures cleanup runs even when go test fails or the user
+	@# Ctrl-Cs the suite. Without it, a failing test left the kind cluster
+	@# behind and the next setup-test-e2e (pre-this-change) skipped
+	@# creation, inheriting the broken state.
+	@trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+		KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e -timeout=30m ./test/e2e/ -v -ginkgo.v
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests


### PR DESCRIPTION
## Summary

Closes #43.

Switches the e2e job off the shared `dagger-labda` runner onto a dedicated kind-only runner (`kind-testing-runner-1`, with `kind-testing-runner-2` available as a sibling).

Run [25041555490](https://github.com/stuttgart-things/sops-secrets-operator/actions/runs/25041555490/job/73345824465) failed with `kubeadm init ... exit status 137` after only 10s — an OOM-kill caused by docker artifacts from unrelated jobs piling up on the shared host. A dedicated runner removes that whole class of infra-side flake; in-test cleanup (#42) covers the cluster-side leak.

## Workflow changes

- `runs-on: dagger-labda` → `runs-on: [self-hosted, kind-testing-runner-1]`
- **Pre-run diagnostics** step (`docker ps -a`, `free -h`, `df -h`) so future infra failures are easier to triage out of the gate.
- **Post-run diagnostics** step (`failure()` only) including the last 200 lines of dockerd journal — cheap insurance against the next runner weirdness.

The existing kind-cluster scrub steps (before + after, the latter with `if: always()`) are kept as belt-and-suspenders alongside the dedicated runner.

## Makefile changes

- `setup-test-e2e`: replace "skip if exists" with **always-delete-then-create**. The previous behaviour let leftover state from a prior failed run poison the next attempt — a recurring flake source on self-hosted runners. Local re-runs are very slightly slower but predictable.
- `test-e2e`: wrap `go test` in a `trap` so `cleanup-test-e2e` runs even if the test fails or the user Ctrl-Cs. Without it, a failing test left the cluster behind, which combined with the old "skip if exists" setup logic to inherit broken state.

## Note on the second runner

I'm using a single label (`kind-testing-runner-1`). With `concurrency: cancel-in-progress` already set, only one e2e job runs at a time anyway, so the second runner is hot-spare / room for a sibling project. If you'd like both runners to load-balance for this repo, add a shared label (e.g. `kind-test`) to both runners and the workflow can switch to that label in a one-line follow-up — let me know.

## Test plan

- [ ] CI `e2e (kind + cert-manager)` job runs on the new runner and passes
- [ ] Re-run the same workflow a second time on this PR — proves no leftover-state regression on the dedicated host (acceptance criterion from #43)
- [ ] Spot-check the pre/post diagnostics output looks sane
- [ ] Local: `make test-e2e` works end-to-end and `make test-e2e` again from a dirty state also works (verifies the always-delete-then-create + trap-cleanup tweaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)