### PR TITLE
feat(observability): emit OpenTelemetry spans around fetch/decrypt/apply (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,22 @@ Each CR has status conditions you can watch with `kubectl get -o jsonpath='{.sta
 - `SopsSecret` / `SopsSecretManifest`: `SourceReady`, `Decrypted`, `Applied`
 - `InlineSopsSecret`: `Decrypted`, `Applied`
 
+### OpenTelemetry tracing (optional)
+
+Set the standard OTLP environment variables on the manager Pod and reconciles will emit one trace per CR with `auth` / `fetch` / `decrypt` / `apply` child spans:
+
+```yaml
+env:
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: http://otel-collector.observability:4317
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: grpc
+  - name: OTEL_SERVICE_NAME
+    value: sops-secrets-operator
+```
+
+Without these vars set, a no-op tracer provider is installed and there is no overhead. Spans carry CR identifiers, `sourceRef`, the observed commit/ETag, and a content-hash fingerprint — never plaintext data or key material. See [SECURITY.md](./SECURITY.md#tracing-emits-no-plaintext-or-key-material) for the full attribute list.
+
 ## Samples
 
 Runnable examples in [`config/samples/`](./config/samples):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,20 @@ Treat write access to the referenced repository as equivalent to namespace-write
 
 Without `spec.revision`, `GitRepository` follows branch HEAD — which means new commits to the branch are picked up on the next poll. For stable pinning, set `spec.revision` to a commit SHA or tag. This also gives you a clean audit trail via `status.lastSyncedCommit`.
 
+### Tracing emits no plaintext or key material
+
+When the operator is configured to export OpenTelemetry traces (`OTEL_EXPORTER_OTLP_ENDPOINT` set), spans carry only resource identifiers and post-decrypt fingerprints:
+
+- `sops.kind`, `sops.namespace`, `sops.name` — the CR being reconciled
+- `sops.source.kind`, `sops.source.name` — its `sourceRef`
+- `sops.commit` — the git commit SHA or object ETag observed at fetch time
+- `sops.content_hash` — a SHA-256 fingerprint of the decrypted Secret data
+- `sops.stage` — `auth` / `fetch` / `decrypt` / `apply` on child spans
+
+Decrypted plaintext, age private keys, basic-auth or SSH credentials, and S3 access keys are **never** placed on spans. Error messages on spans come from the same paths that already surface in `status.conditions[].message`, so they may include source or upstream library text but not key material.
+
+Because spans expose CR identifiers, namespace names, and source URLs/SHAs to whatever collector you target, route traces to a destination governed by the same operators-only access controls you apply to the operator's logs.
+
 ## Reporting a vulnerability
 
 Please email [phermann1988@gmail.com](mailto:phermann1988@gmail.com) with details. Do not open a public issue for undisclosed vulnerabilities.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -40,8 +42,13 @@ import (
 	sopsv1alpha2 "github.com/stuttgart-things/sops-secrets-operator/api/v1alpha2"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/controller"
 	"github.com/stuttgart-things/sops-secrets-operator/internal/source"
+	"github.com/stuttgart-things/sops-secrets-operator/internal/tracing"
 	// +kubebuilder:scaffold:imports
 )
+
+// version is the operator version reported as service.version on emitted
+// OTel spans. Override at build time with -ldflags "-X main.version=…".
+var version = "dev"
 
 var (
 	scheme   = runtime.NewScheme()
@@ -90,6 +97,22 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Tracing is opt-in via OTEL_EXPORTER_OTLP_ENDPOINT (or _TRACES_ENDPOINT).
+	// With no endpoint configured, Setup installs a no-op TracerProvider so
+	// reconciler instrumentation stays free.
+	tracerShutdown, err := tracing.Setup(context.Background(), version)
+	if err != nil {
+		setupLog.Error(err, "Failed to set up tracing")
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracerShutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "tracer shutdown failed")
+		}
+	}()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,18 @@ module github.com/stuttgart-things/sops-secrets-operator
 go 1.26.0
 
 require (
+	filippo.io/age v1.3.1
 	github.com/getsops/sops/v3 v3.12.2
 	github.com/go-git/go-git/v5 v5.18.0
+	github.com/google/go-cmp v0.7.0
+	github.com/minio/minio-go/v7 v7.0.100
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0
+	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/crypto v0.48.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -28,7 +35,6 @@ require (
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/storage v1.60.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
-	filippo.io/age v1.3.1 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
 	filippo.io/hpke v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
@@ -69,6 +75,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
@@ -103,7 +110,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -111,7 +117,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -138,7 +144,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/minio/minio-go/v7 v7.0.100 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -174,14 +179,10 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
+	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -293,8 +295,8 @@ github.com/googleapis/gax-go/v2 v2.17.0 h1:RksgfBpxqff0EZkDWYuz9q/uWsTVz+kf43LsZ
 github.com/googleapis/gax-go/v2 v2.17.0/go.mod h1:mzaqghpQp4JDh3HvADwrat+6M3MOIDp5YKHhb9PAgDY=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 h1:X5VWvz21y3gzm9Nw/kaUeku/1+uBhcekkmy4IkffJww=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7/go.mod h1:lW34nIZuQ8UDPdkon5fmfp2l3+ZkQ2me/+oecHYLOII=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -335,8 +337,6 @@ github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -515,10 +515,10 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6h
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 h1:OeNbIYk/2C15ckl7glBlOBp5+WlYsOElzTNmiPW/x60=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0/go.mod h1:7Bept48yIeqxP2OZ9/AqIpYS94h2or0aB4FypJTc8ZM=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 h1:tgJ0uaNS4c98WRNUEx5U3aDlrDOI5Rs+1Vifcw4DJ8U=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0/go.mod h1:U7HYyW0zt/a9x5J1Kjs+r1f/d4ZHnYFclhYY2+YbeoE=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 h1:QKdN8ly8zEMrByybbQgv8cWBcdAarwmIPZ6FThrWXJs=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0/go.mod h1:bTdK1nhqF76qiPoCCdyFIV+N/sRHYXYCTQc+3VCi3MI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 h1:DvJDOPmSWQHWywQS6lKL+pb8s3gBLOZUtw4N+mavW1I=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0/go.mod h1:EtekO9DEJb4/jRyN4v4Qjc2yA7AtfCBuz2FynRUWTXs=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.39.0 h1:5gn2urDL/FBnK8OkCfD1j3/ER79rUuTYmCvlXBKeYL8=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.39.0/go.mod h1:0fBG6ZJxhqByfFZDwSwpZGzJU671HkwpWaNe2t4VUPI=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=
@@ -529,8 +529,8 @@ go.opentelemetry.io/otel/sdk/metric v1.40.0 h1:mtmdVqgQkeRxHgRv4qhyJduP3fYJRMX4A
 go.opentelemetry.io/otel/sdk/metric v1.40.0/go.mod h1:4Z2bGMf0KSK3uRjlczMOeMhKU2rhUqdWNoKcYrtcBPg=
 go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZYblVjw=
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
-go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
-go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
+go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
+go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -62,8 +62,8 @@ type GitRepositoryReconciler struct {
 
 func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithValues("gitrepository", req.NamespacedName)
-	setStage, finish := trackReconcile("GitRepository")
-	defer finish()
+	ctx, t := trackReconcile(ctx, "GitRepository", req.Namespace, req.Name)
+	defer t.Finish()
 
 	var gr sopsv1alpha1.GitRepository
 	if err := r.Get(ctx, req.NamespacedName, &gr); err != nil {
@@ -87,10 +87,11 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.Registry.Forget(req.NamespacedName)
 	}
 
-	auth, err := r.resolveAuth(ctx, &gr)
+	authCtx := t.Stage(ctx, StageAuth)
+	auth, err := r.resolveAuth(authCtx, &gr)
 	if err != nil {
 		log.Error(err, "auth resolution failed")
-		setStage(StageAuth)
+		t.Fail(StageAuth, err)
 		setCondition(&gr.Status.Conditions, sopsv1alpha1.ConditionAuthResolved, metav1.ConditionFalse, "AuthFailed", err.Error())
 		setCondition(&gr.Status.Conditions, sopsv1alpha1.ConditionSourceReady, metav1.ConditionFalse, "AuthFailed", "waiting for auth")
 		gr.Status.CacheReady = false
@@ -107,10 +108,11 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		Revision: gr.Spec.Revision,
 		Auth:     auth,
 	}
-	sha, err := r.Registry.EnsureCached(ctx, req.NamespacedName, cfg)
+	fetchCtx := t.Stage(ctx, StageFetch)
+	sha, err := r.Registry.EnsureCached(fetchCtx, req.NamespacedName, cfg)
 	if err != nil {
 		log.Error(err, "fetch failed")
-		setStage(StageFetch)
+		t.Fail(StageFetch, err)
 		setCondition(&gr.Status.Conditions, sopsv1alpha1.ConditionSourceReady, metav1.ConditionFalse, "FetchFailed", err.Error())
 		gr.Status.CacheReady = false
 		if uerr := r.Status().Update(ctx, &gr); uerr != nil {
@@ -118,6 +120,7 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		return ctrl.Result{RequeueAfter: retryAfter}, nil
 	}
+	t.SetCommit(sha)
 
 	gr.Status.LastSyncedCommit = sha
 	gr.Status.CacheReady = true

--- a/internal/controller/inlinesopssecret_controller.go
+++ b/internal/controller/inlinesopssecret_controller.go
@@ -51,8 +51,8 @@ type InlineSopsSecretReconciler struct {
 
 func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithValues("inlinesopssecret", req.NamespacedName)
-	setStage, finish := trackReconcile("InlineSopsSecret")
-	defer finish()
+	ctx, t := trackReconcile(ctx, "InlineSopsSecret", req.Namespace, req.Name)
+	defer t.Finish()
 
 	var is sopsv1alpha1.InlineSopsSecret
 	if err := r.Get(ctx, req.NamespacedName, &is); err != nil {
@@ -82,17 +82,18 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Resolve age key and decrypt the inline payload.
-	ageKey, err := keyresolve.Age(ctx, r.Client, is.Namespace, keyresolve.SecretKeyRef{
+	decryptCtx := t.Stage(ctx, StageDecrypt)
+	ageKey, err := keyresolve.Age(decryptCtx, r.Client, is.Namespace, keyresolve.SecretKeyRef{
 		Name: is.Spec.Decryption.KeyRef.Name,
 		Key:  is.Spec.Decryption.KeyRef.Key,
 	})
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "KeyResolveFailed", err.Error())
 	}
 	plaintext, err := decrypt.DecryptAge([]byte(is.Spec.EncryptedYAML), inlineSopsDecryptPath, ageKey)
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "DecryptFailed", err.Error())
 	}
 
@@ -101,20 +102,22 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	case sopsv1alpha1.InlineModeMapping:
 		flat, err := transform.ParseFlatYAML(plaintext)
 		if err != nil {
-			setStage(StageDecrypt)
+			t.Fail(StageDecrypt, err)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "ParseFailed", err.Error())
 		}
 		data, err := transform.ApplyMapping(flat, convertInlineDataMappings(is.Spec.Data))
 		if err != nil {
-			setStage(StageDecrypt)
+			t.Fail(StageDecrypt, err)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "MappingFailed", err.Error())
 		}
 		setCondition(&is.Status.Conditions, sopsv1alpha1.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + mapping ok")
 
 		hash := transform.HashSecretData(data)
-		if err := r.applyInlineMappingSecret(ctx, &is, data, hash); err != nil {
+		t.SetContentHash(hash)
+		applyCtx := t.Stage(ctx, StageApply)
+		if err := r.applyInlineMappingSecret(applyCtx, &is, data, hash); err != nil {
 			log.Error(err, "apply inline mapping secret failed")
-			setStage(StageApply)
+			t.Fail(StageApply, err)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionApplied, "ApplyFailed", err.Error())
 		}
 		setCondition(&is.Status.Conditions, sopsv1alpha1.ConditionApplied, metav1.ConditionTrue, "Applied",
@@ -124,7 +127,7 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	case sopsv1alpha1.InlineModeManifest:
 		parsed, err := transform.ParseManifest(plaintext)
 		if err != nil {
-			setStage(StageDecrypt)
+			t.Fail(StageDecrypt, err)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "ParseFailed", err.Error())
 		}
 		transform.NormalizeSecretData(parsed)
@@ -134,9 +137,9 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			name = parsed.Name
 		}
 		if name == "" {
-			setStage(StageDecrypt)
-			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "NameMissing",
-				"manifest has no metadata.name and spec.target.name is not set")
+			err := fmt.Errorf("manifest has no metadata.name and spec.target.name is not set")
+			t.Fail(StageDecrypt, err)
+			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "NameMissing", err.Error())
 		}
 		ns := is.Spec.Target.Namespace
 		if ns == "" {
@@ -145,9 +148,11 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		setCondition(&is.Status.Conditions, sopsv1alpha1.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + validation ok")
 
 		hash := transform.HashManifestSecret(parsed)
-		if err := r.applyInlineManifestSecret(ctx, &is, parsed, name, ns, hash); err != nil {
+		t.SetContentHash(hash)
+		applyCtx := t.Stage(ctx, StageApply)
+		if err := r.applyInlineManifestSecret(applyCtx, &is, parsed, name, ns, hash); err != nil {
 			log.Error(err, "apply inline manifest secret failed")
-			setStage(StageApply)
+			t.Fail(StageApply, err)
 			return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionApplied, "ApplyFailed", err.Error())
 		}
 		setCondition(&is.Status.Conditions, sopsv1alpha1.ConditionApplied, metav1.ConditionTrue, "Applied",
@@ -155,9 +160,9 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		is.Status.LastAppliedHash = hash
 
 	default:
-		setStage(StageDecrypt)
-		return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "InvalidMode",
-			fmt.Sprintf("unknown mode %q", is.Spec.Mode))
+		err := fmt.Errorf("unknown mode %q", is.Spec.Mode)
+		t.Fail(StageDecrypt, err)
+		return r.failInlineStatus(ctx, &is, sopsv1alpha1.ConditionDecrypted, "InvalidMode", err.Error())
 	}
 
 	is.Status.LastProcessedReconcileToken = is.Annotations[ReconcileRequestAnnotation]

--- a/internal/controller/labels.go
+++ b/internal/controller/labels.go
@@ -11,12 +11,20 @@ You may obtain a copy of the License at
 package controller
 
 import (
+	"context"
+	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/stuttgart-things/sops-secrets-operator/internal/metrics"
+	"github.com/stuttgart-things/sops-secrets-operator/internal/tracing"
 )
 
-// Reconcile stage labels used on the sops_reconcile_errors_total counter.
+// Reconcile stage labels used on the sops_reconcile_errors_total counter
+// and as child-span names in OTel traces.
 const (
 	StageAuth    = "auth"
 	StageFetch   = "fetch"
@@ -24,26 +32,136 @@ const (
 	StageApply   = "apply"
 )
 
-// trackReconcile is called at the top of each Reconcile and returns a
-// setter for the error stage plus a deferred finisher. Usage:
+// reconcileTracker collects per-reconcile metrics and spans. One is
+// created at the top of each Reconcile via trackReconcile and finalized
+// via Finish. Stage starts a child span scoped to one of the StageX
+// constants; calling it again ends the previous child first.
 //
-//	setStage, finish := trackReconcile("GitRepository")
-//	defer finish()
-//	// on failure path:
-//	setStage(StageAuth)
-//	return r.failStatus(...)
-func trackReconcile(kind string) (setStage func(string), finish func()) {
-	start := time.Now()
-	var stage string
-	return func(s string) { stage = s }, func() {
-		result := metrics.ResultSuccess
-		if stage != "" {
-			result = metrics.ResultError
-			metrics.ReconcileErrorsTotal.WithLabelValues(kind, stage).Inc()
-		}
-		metrics.ReconcileTotal.WithLabelValues(kind, result).Inc()
-		metrics.ReconcileDurationSeconds.WithLabelValues(kind, result).Observe(time.Since(start).Seconds())
+// Spans never carry plaintext data or key material — only resource
+// identifiers (namespace/name/kind/sourceRef) and post-decrypt
+// fingerprints (commit SHA, content hash).
+type reconcileTracker struct {
+	metricKind string
+	start      time.Time
+	failStage  string
+
+	rootSpan  trace.Span
+	stageSpan trace.Span
+}
+
+// trackReconcile starts the metrics timer and the root span for a
+// reconcile. Callers should:
+//
+//	ctx, t := trackReconcile(ctx, "SopsSecret", req.Namespace, req.Name)
+//	defer t.Finish()
+//	ctx = t.Stage(ctx, StageFetch) // before the fetch call
+//	...
+//	if err != nil { t.Fail(StageFetch, err); return ... }
+//
+// The returned context carries the root span; pass it down so any
+// span-aware callees nest beneath it.
+func trackReconcile(ctx context.Context, kind, namespace, name string) (context.Context, *reconcileTracker) {
+	t := &reconcileTracker{
+		metricKind: kind,
+		start:      time.Now(),
 	}
+	ctx, t.rootSpan = tracing.Tracer().Start(ctx,
+		fmt.Sprintf("%s.Reconcile", kind),
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("sops.kind", kind),
+			attribute.String("sops.namespace", namespace),
+			attribute.String("sops.name", name),
+		),
+	)
+	return ctx, t
+}
+
+// Stage closes any open child span and starts a new one for the given
+// stage. The returned context is scoped to the new child span.
+func (t *reconcileTracker) Stage(ctx context.Context, stage string) context.Context {
+	if t.stageSpan != nil {
+		t.stageSpan.End()
+		t.stageSpan = nil
+	}
+	ctx, t.stageSpan = tracing.Tracer().Start(ctx, "stage."+stage,
+		trace.WithAttributes(attribute.String("sops.stage", stage)),
+	)
+	return ctx
+}
+
+// Fail marks the given stage as the failure point. The error is
+// recorded on the active child span (if any) and the root span, both
+// of which get codes.Error status. The metric label is set so Finish
+// records sops_reconcile_errors_total{stage=...}.
+func (t *reconcileTracker) Fail(stage string, err error) {
+	t.failStage = stage
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	if t.stageSpan != nil {
+		if err != nil {
+			t.stageSpan.RecordError(err)
+		}
+		t.stageSpan.SetStatus(codes.Error, msg)
+	}
+	if t.rootSpan != nil {
+		if err != nil {
+			t.rootSpan.RecordError(err)
+		}
+		t.rootSpan.SetStatus(codes.Error, msg)
+	}
+}
+
+// SetSourceRef adds source-kind / source-name attributes to the root
+// span once they are known. Safe to call before the first Stage.
+func (t *reconcileTracker) SetSourceRef(kind, name string) {
+	if t.rootSpan == nil {
+		return
+	}
+	t.rootSpan.SetAttributes(
+		attribute.String("sops.source.kind", kind),
+		attribute.String("sops.source.name", name),
+	)
+}
+
+// SetCommit annotates the root span with the source revision (commit
+// SHA for git, ETag for object storage) once observed.
+func (t *reconcileTracker) SetCommit(revision string) {
+	if t.rootSpan == nil || revision == "" {
+		return
+	}
+	t.rootSpan.SetAttributes(attribute.String("sops.commit", revision))
+}
+
+// SetContentHash annotates the root span with the post-decrypt content
+// hash. The hash is a fingerprint, not plaintext.
+func (t *reconcileTracker) SetContentHash(hash string) {
+	if t.rootSpan == nil || hash == "" {
+		return
+	}
+	t.rootSpan.SetAttributes(attribute.String("sops.content_hash", hash))
+}
+
+// Finish ends any open child span and the root span, then writes the
+// reconcile metrics. Must be called via defer at the top of Reconcile.
+func (t *reconcileTracker) Finish() {
+	if t.stageSpan != nil {
+		t.stageSpan.End()
+		t.stageSpan = nil
+	}
+	if t.rootSpan != nil {
+		t.rootSpan.End()
+	}
+
+	result := metrics.ResultSuccess
+	if t.failStage != "" {
+		result = metrics.ResultError
+		metrics.ReconcileErrorsTotal.WithLabelValues(t.metricKind, t.failStage).Inc()
+	}
+	metrics.ReconcileTotal.WithLabelValues(t.metricKind, result).Inc()
+	metrics.ReconcileDurationSeconds.WithLabelValues(t.metricKind, result).Observe(time.Since(t.start).Seconds())
 }
 
 // Labels and annotations set on every target Secret produced by this operator.

--- a/internal/controller/objectsource_controller.go
+++ b/internal/controller/objectsource_controller.go
@@ -56,8 +56,8 @@ type ObjectSourceReconciler struct {
 
 func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithValues("objectsource", req.NamespacedName)
-	setStage, finish := trackReconcile("ObjectSource")
-	defer finish()
+	ctx, t := trackReconcile(ctx, "ObjectSource", req.Namespace, req.Name)
+	defer t.Finish()
 
 	var os sopsv1alpha2.ObjectSource
 	if err := r.Get(ctx, req.NamespacedName, &os); err != nil {
@@ -88,7 +88,7 @@ func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	hasBucket := os.Spec.Bucket != nil
 	if hasURL == hasBucket {
 		err := fmt.Errorf("exactly one of spec.url or spec.bucket must be set")
-		setStage(StageAuth)
+		t.Fail(StageAuth, err)
 		setObjectFailure(&os, ObjectConditionAuthResolved, "InvalidSpec", err.Error())
 		if uerr := r.Status().Update(ctx, &os); uerr != nil {
 			return ctrl.Result{}, uerr
@@ -96,10 +96,11 @@ func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: retryAfter}, nil
 	}
 
-	fetcher, mode, err := r.buildFetcher(ctx, &os)
+	authCtx := t.Stage(ctx, StageAuth)
+	fetcher, mode, err := r.buildFetcher(authCtx, &os)
 	if err != nil {
 		log.Error(err, "auth resolution failed")
-		setStage(StageAuth)
+		t.Fail(StageAuth, err)
 		setObjectFailure(&os, ObjectConditionAuthResolved, "AuthFailed", err.Error())
 		if uerr := r.Status().Update(ctx, &os); uerr != nil {
 			return ctrl.Result{}, uerr
@@ -108,10 +109,11 @@ func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	setCondition(&os.Status.Conditions, ObjectConditionAuthResolved, metav1.ConditionTrue, "AuthOK", "auth resolved")
 
-	etag, err := r.Registry.EnsureObjectCached(ctx, req.NamespacedName, mode, fetcher)
+	fetchCtx := t.Stage(ctx, StageFetch)
+	etag, err := r.Registry.EnsureObjectCached(fetchCtx, req.NamespacedName, mode, fetcher)
 	if err != nil {
 		log.Error(err, "fetch failed")
-		setStage(StageFetch)
+		t.Fail(StageFetch, err)
 		setCondition(&os.Status.Conditions, ObjectConditionSourceReady, metav1.ConditionFalse, "FetchFailed", err.Error())
 		os.Status.CacheReady = false
 		if uerr := r.Status().Update(ctx, &os); uerr != nil {
@@ -119,6 +121,7 @@ func (r *ObjectSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return ctrl.Result{RequeueAfter: retryAfter}, nil
 	}
+	t.SetCommit(etag)
 
 	now := metav1.NewTime(time.Now())
 	os.Status.LastSyncedETag = etag

--- a/internal/controller/sopssecret_controller.go
+++ b/internal/controller/sopssecret_controller.go
@@ -61,8 +61,8 @@ type SopsSecretReconciler struct {
 
 func (r *SopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithValues("sopssecret", req.NamespacedName)
-	setStage, finish := trackReconcile("SopsSecret")
-	defer finish()
+	ctx, t := trackReconcile(ctx, "SopsSecret", req.Namespace, req.Name)
+	defer t.Finish()
 
 	var ss sopsv1alpha2.SopsSecret
 	if err := r.Get(ctx, req.NamespacedName, &ss); err != nil {
@@ -91,45 +91,52 @@ func (r *SopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	t.SetSourceRef(string(ss.Spec.Source.SourceRef.Kind), ss.Spec.Source.SourceRef.Name)
+
 	// Resolve the source CR by sourceRef.Kind, fetch the encrypted bytes
 	// plus a "revision" string (commit SHA for git, ETag for object).
-	content, revision, srcErr := r.fetchSource(ctx, &ss)
+	fetchCtx := t.Stage(ctx, StageFetch)
+	content, revision, srcErr := r.fetchSource(fetchCtx, &ss)
 	if srcErr != nil {
-		setStage(StageFetch)
+		t.Fail(StageFetch, srcErr)
 		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionSourceReady, srcErr.reason, srcErr.msg)
 	}
+	t.SetCommit(revision)
 	setCondition(&ss.Status.Conditions, sopsv1alpha2.ConditionSourceReady, metav1.ConditionTrue, "Ready", "source is ready")
 
-	ageKey, err := keyresolve.Age(ctx, r.Client, ss.Namespace, keyresolve.SecretKeyRef{
+	decryptCtx := t.Stage(ctx, StageDecrypt)
+	ageKey, err := keyresolve.Age(decryptCtx, r.Client, ss.Namespace, keyresolve.SecretKeyRef{
 		Name: ss.Spec.Decryption.KeyRef.Name,
 		Key:  ss.Spec.Decryption.KeyRef.Key,
 	})
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "KeyResolveFailed", err.Error())
 	}
 	plaintext, err := decrypt.DecryptAge(content, ss.Spec.Source.Path, ageKey)
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "DecryptFailed", err.Error())
 	}
 
 	flat, err := transform.ParseFlatYAML(plaintext)
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "ParseFailed", err.Error())
 	}
 	data, err := transform.ApplyMapping(flat, convertSpecDataMappings(ss.Spec.Data))
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionDecrypted, "MappingFailed", err.Error())
 	}
 	setCondition(&ss.Status.Conditions, sopsv1alpha2.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + mapping ok")
 
 	hash := transform.HashSecretData(data)
-	if err := r.applyTargetSecret(ctx, &ss, data, hash, revision); err != nil {
+	t.SetContentHash(hash)
+	applyCtx := t.Stage(ctx, StageApply)
+	if err := r.applyTargetSecret(applyCtx, &ss, data, hash, revision); err != nil {
 		log.Error(err, "apply target secret failed")
-		setStage(StageApply)
+		t.Fail(StageApply, err)
 		return r.failStatus(ctx, &ss, sopsv1alpha2.ConditionApplied, "ApplyFailed", err.Error())
 	}
 	setCondition(&ss.Status.Conditions, sopsv1alpha2.ConditionApplied, metav1.ConditionTrue, "Applied",

--- a/internal/controller/sopssecretmanifest_controller.go
+++ b/internal/controller/sopssecretmanifest_controller.go
@@ -58,8 +58,8 @@ type SopsSecretManifestReconciler struct {
 
 func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithValues("sopssecretmanifest", req.NamespacedName)
-	setStage, finish := trackReconcile("SopsSecretManifest")
-	defer finish()
+	ctx, t := trackReconcile(ctx, "SopsSecretManifest", req.Namespace, req.Name)
+	defer t.Finish()
 
 	var sm sopsv1alpha2.SopsSecretManifest
 	if err := r.Get(ctx, req.NamespacedName, &sm); err != nil {
@@ -88,30 +88,35 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	content, revision, srcErr := r.fetchManifestSource(ctx, &sm)
+	t.SetSourceRef(string(sm.Spec.Source.SourceRef.Kind), sm.Spec.Source.SourceRef.Name)
+
+	fetchCtx := t.Stage(ctx, StageFetch)
+	content, revision, srcErr := r.fetchManifestSource(fetchCtx, &sm)
 	if srcErr != nil {
-		setStage(StageFetch)
+		t.Fail(StageFetch, srcErr)
 		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionSourceReady, srcErr.reason, srcErr.msg)
 	}
+	t.SetCommit(revision)
 	setCondition(&sm.Status.Conditions, sopsv1alpha2.ConditionSourceReady, metav1.ConditionTrue, "Ready", "source is ready")
 
-	ageKey, err := keyresolve.Age(ctx, r.Client, sm.Namespace, keyresolve.SecretKeyRef{
+	decryptCtx := t.Stage(ctx, StageDecrypt)
+	ageKey, err := keyresolve.Age(decryptCtx, r.Client, sm.Namespace, keyresolve.SecretKeyRef{
 		Name: sm.Spec.Decryption.KeyRef.Name,
 		Key:  sm.Spec.Decryption.KeyRef.Key,
 	})
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "KeyResolveFailed", err.Error())
 	}
 	plaintext, err := decrypt.DecryptAge(content, sm.Spec.Source.Path, ageKey)
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "DecryptFailed", err.Error())
 	}
 
 	parsed, err := transform.ParseManifest(plaintext)
 	if err != nil {
-		setStage(StageDecrypt)
+		t.Fail(StageDecrypt, err)
 		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "ParseFailed", err.Error())
 	}
 	transform.NormalizeSecretData(parsed)
@@ -125,16 +130,18 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		targetName = parsed.Name
 	}
 	if targetName == "" {
-		setStage(StageDecrypt)
-		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "NameMissing",
-			"manifest has no metadata.name and target.nameOverride is not set")
+		err := fmt.Errorf("manifest has no metadata.name and target.nameOverride is not set")
+		t.Fail(StageDecrypt, err)
+		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionDecrypted, "NameMissing", err.Error())
 	}
 	setCondition(&sm.Status.Conditions, sopsv1alpha2.ConditionDecrypted, metav1.ConditionTrue, "Decrypted", "decryption + validation ok")
 
 	hash := transform.HashManifestSecret(parsed)
-	if err := r.applyManifestSecret(ctx, &sm, parsed, targetName, targetNS, hash, revision); err != nil {
+	t.SetContentHash(hash)
+	applyCtx := t.Stage(ctx, StageApply)
+	if err := r.applyManifestSecret(applyCtx, &sm, parsed, targetName, targetNS, hash, revision); err != nil {
 		log.Error(err, "apply manifest secret failed")
-		setStage(StageApply)
+		t.Fail(StageApply, err)
 		return r.failManifestStatus(ctx, &sm, sopsv1alpha2.ConditionApplied, "ApplyFailed", err.Error())
 	}
 	setCondition(&sm.Status.Conditions, sopsv1alpha2.ConditionApplied, metav1.ConditionTrue, "Applied",

--- a/internal/controller/tracking_test.go
+++ b/internal/controller/tracking_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// installInMemoryTracer swaps the global tracer provider for one that
+// records every emitted span into the returned exporter. The previous
+// provider is restored on test teardown.
+func installInMemoryTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return exp
+}
+
+func TestReconcileTracker_HappyPath_EmitsRootAndStageSpans(t *testing.T) {
+	exp := installInMemoryTracer(t)
+
+	ctx, tr := trackReconcile(context.Background(), "SopsSecret", "ns", "obj")
+	tr.SetSourceRef("GitRepository", "src")
+	ctx = tr.Stage(ctx, StageFetch)
+	tr.SetCommit("abc1234")
+	ctx = tr.Stage(ctx, StageDecrypt)
+	tr.SetContentHash("hashvalue")
+	_ = tr.Stage(ctx, StageApply)
+	tr.Finish()
+
+	spans := exp.GetSpans()
+	if len(spans) != 4 {
+		t.Fatalf("expected 4 spans (3 stages + root), got %d", len(spans))
+	}
+
+	// The root span ends last, so it sorts last in the in-memory exporter.
+	root := spans[len(spans)-1]
+	if root.Name != "SopsSecret.Reconcile" {
+		t.Fatalf("expected root span SopsSecret.Reconcile, got %q", root.Name)
+	}
+
+	wantAttrs := map[string]string{
+		"sops.kind":         "SopsSecret",
+		"sops.namespace":    "ns",
+		"sops.name":         "obj",
+		"sops.source.kind":  "GitRepository",
+		"sops.source.name":  "src",
+		"sops.commit":       "abc1234",
+		"sops.content_hash": "hashvalue",
+	}
+	got := map[string]string{}
+	for _, a := range root.Attributes {
+		got[string(a.Key)] = a.Value.AsString()
+	}
+	for k, v := range wantAttrs {
+		if got[k] != v {
+			t.Errorf("root span attr %q = %q; want %q", k, got[k], v)
+		}
+	}
+
+	wantStages := []string{"stage." + StageFetch, "stage." + StageDecrypt, "stage." + StageApply}
+	for i, name := range wantStages {
+		if spans[i].Name != name {
+			t.Errorf("span[%d] name = %q; want %q", i, spans[i].Name, name)
+		}
+	}
+}
+
+func TestReconcileTracker_FailMarksStageAndRootErrored(t *testing.T) {
+	exp := installInMemoryTracer(t)
+
+	ctx, tr := trackReconcile(context.Background(), "SopsSecret", "ns", "obj")
+	ctx = tr.Stage(ctx, StageFetch)
+	_ = tr.Stage(ctx, StageDecrypt)
+	tr.Fail(StageDecrypt, errors.New("boom"))
+	tr.Finish()
+
+	spans := exp.GetSpans()
+	if len(spans) != 3 {
+		t.Fatalf("expected 3 spans, got %d", len(spans))
+	}
+
+	// Last span is the root; the second is the decrypt stage (because
+	// Stage() ends the previous fetch span before opening decrypt).
+	root := spans[len(spans)-1]
+	if root.Status.Code != otelcodes.Error {
+		t.Errorf("root span status = %v; want Error", root.Status.Code)
+	}
+
+	var decryptSpan *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "stage."+StageDecrypt {
+			decryptSpan = &spans[i]
+			break
+		}
+	}
+	if decryptSpan == nil {
+		t.Fatalf("did not find stage.decrypt span")
+	}
+	if decryptSpan.Status.Code != otelcodes.Error {
+		t.Errorf("decrypt span status = %v; want Error", decryptSpan.Status.Code)
+	}
+	if len(decryptSpan.Events) == 0 {
+		t.Errorf("expected RecordError event on decrypt span, got none")
+	}
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Package tracing wires an OTLP/gRPC trace exporter onto OpenTelemetry's
+// global TracerProvider. It is opt-in: if no OTLP endpoint is configured
+// in the environment, Setup installs a no-op provider so call sites that
+// start spans are still safe.
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// ServiceName is the value reported as service.name when no
+// OTEL_SERVICE_NAME is set. It also feeds the Tracer name used by the
+// controllers, so spans group cleanly in collectors.
+const ServiceName = "sops-secrets-operator"
+
+// ShutdownFunc flushes pending spans and tears down the exporter. It is
+// safe to call on the no-op path; in that case it is a no-op too.
+type ShutdownFunc func(context.Context) error
+
+// Setup installs an OTLP/gRPC tracer provider as the global tracer
+// provider when an endpoint is configured via the standard OTEL_*
+// environment variables (OTEL_EXPORTER_OTLP_ENDPOINT,
+// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, …). When no endpoint is set or
+// OTEL_SDK_DISABLED=true, a noop provider is installed and Setup
+// returns a no-op shutdown.
+func Setup(ctx context.Context, version string) (ShutdownFunc, error) {
+	if disabled() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		return func(context.Context) error { return nil }, nil
+	}
+
+	exp, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithProcess(),
+		resource.WithTelemetrySDK(),
+		resource.WithAttributes(
+			semconv.ServiceName(ServiceName),
+			semconv.ServiceVersion(version),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build resource: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	return tp.Shutdown, nil
+}
+
+// Tracer returns the controller-scoped tracer. Using a single name keeps
+// instrumentation scope consistent in the collector.
+func Tracer() trace.Tracer { return otel.Tracer(ServiceName) }
+
+// disabled reports whether tracing should be skipped. We treat a missing
+// endpoint as "off" so the operator runs unchanged when OTel is not in
+// use, even though the SDK can technically default to localhost.
+func disabled() bool {
+	if v := os.Getenv("OTEL_SDK_DISABLED"); v == "true" {
+		return true
+	}
+	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" &&
+		os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") == "" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Opt-in OTLP/gRPC tracer wired via standard `OTEL_*` env vars; no-op TracerProvider when no endpoint is set, so no overhead by default.
- Each reconcile emits a root span (`<Kind>.Reconcile`) with `auth` / `fetch` / `decrypt` / `apply` child spans across all 5 controllers.
- Span attributes carry CR/source identifiers (`sops.kind/namespace/name`, `sops.source.kind/name`), the observed `sops.commit` (git SHA or object ETag) and a `sops.content_hash` fingerprint after decrypt — never plaintext or key material. Errors are recorded on both the failing stage span and the root span.
- README §"OpenTelemetry tracing (optional)" + SECURITY.md §"Tracing emits no plaintext or key material".

Closes #22.

## Test plan

- [x] `make test` (vet + envtest + unit) passes locally
- [x] New unit tests with an in-memory tracer assert (a) happy path emits 4 spans with all expected attributes and (b) a decrypt failure marks both the stage and root spans `Error`
- [ ] Manual smoke: deploy with `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at a collector, observe one trace per reconcile with stage children
- [ ] Manual: confirm span attributes contain no plaintext / age key / basic-auth credentials in the collector

🤖 Generated with [Claude Code](https://claude.com/claude-code)