### PR TITLE
fix(controllers): re-apply target Secrets periodically

### DIFF
--- a/internal/controller/gitrepository_controller.go
+++ b/internal/controller/gitrepository_controller.go
@@ -42,6 +42,16 @@ const (
 	// retryAfter is the backoff between retries when a reconcile fails.
 	retryAfter = 30 * time.Second
 
+	// resyncAfter is how long a secret-producing reconciler waits before
+	// re-applying an object that already succeeded.
+	//
+	// Without it a successful reconcile is terminal: nothing watches the
+	// Secret we write (it may live in another namespace via target.namespace,
+	// so ownerReferences — and therefore Owns() — do not apply), so a Secret
+	// deleted out of band never comes back while the CR still reports
+	// Applied=True. See #83.
+	resyncAfter = 5 * time.Minute
+
 	// GitRepoAuthSecretIndex is a field index on GitRepository pointing at
 	// the name of its auth secret reference. Used to enqueue GitRepositories
 	// when a referenced Secret changes.

--- a/internal/controller/gitsourced_happypath_test.go
+++ b/internal/controller/gitsourced_happypath_test.go
@@ -392,5 +392,72 @@ stringData:
 			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "manifest-name"}, &corev1.Secret{})
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
+
+		// Regression for #83: a successful reconcile used to be terminal, so a
+		// target Secret deleted out of band never came back while the CR still
+		// reported Applied=True. Nothing watches the Secret (target.namespace
+		// may differ from the CR's, so ownerReferences do not apply), which
+		// makes the periodic requeue the only thing that restores it.
+		It("requeues after a successful apply and re-creates a deleted target Secret", func() {
+			prefix := uniq("sm-resync")
+			manifest := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: resync-target
+type: Opaque
+stringData:
+  token: keep-me
+`)
+			fx := newGitFixture(prefix, "sec.enc.yaml", manifest)
+
+			cr := &sopsv1alpha2.SopsSecretManifest{
+				ObjectMeta: metav1.ObjectMeta{Name: prefix, Namespace: namespace},
+				Spec: sopsv1alpha2.SopsSecretManifestSpec{
+					Source: gitSourceRef(fx.repoCRRef, "sec.enc.yaml"),
+					Decryption: sopsv1alpha2.DecryptionSpec{
+						KeyRef: sopsv1alpha2.SecretKeyRef{Name: fx.keyRef, Key: "age.agekey"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconr := &SopsSecretManifestReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Registry: fx.registry,
+			}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: prefix},
+			}
+
+			var res reconcile.Result
+			for range 2 {
+				var err error
+				res, err = reconr.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// The successful reconcile must schedule another one.
+			Expect(res.RequeueAfter).To(Equal(resyncAfter))
+
+			targetKey := types.NamespacedName{Namespace: namespace, Name: "resync-target"}
+			Expect(k8sClient.Get(ctx, targetKey, &corev1.Secret{})).To(Succeed())
+
+			// Drop the Secret the way an out-of-band delete would.
+			Expect(k8sClient.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "resync-target"},
+			})).To(Succeed())
+			Expect(apierrors.IsNotFound(
+				k8sClient.Get(ctx, targetKey, &corev1.Secret{}),
+			)).To(BeTrue())
+
+			// What the requeue will do when it fires.
+			_, err := reconr.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			restored := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, targetKey, restored)).To(Succeed())
+			Expect(string(restored.Data["token"])).To(Equal("keep-me"))
+		})
 	})
 })

--- a/internal/controller/inlinesopssecret_controller.go
+++ b/internal/controller/inlinesopssecret_controller.go
@@ -170,7 +170,10 @@ func (r *InlineSopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.Status().Update(ctx, &is); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Re-apply periodically. This controller has no source watch at all, so
+	// before this it went permanently idle after the first successful apply
+	// and a Secret removed out of band never returned (#83).
+	return ctrl.Result{RequeueAfter: resyncAfter}, nil
 }
 
 func convertInlineDataMappings(in []sopsv1alpha1.DataMapping) []transform.DataMapping {

--- a/internal/controller/sopssecret_controller.go
+++ b/internal/controller/sopssecret_controller.go
@@ -149,7 +149,9 @@ func (r *SopsSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err := r.Status().Update(ctx, &ss); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Re-apply periodically: the target Secret is not watched, so this is the
+	// only thing that restores it if it is removed out of band (#83).
+	return ctrl.Result{RequeueAfter: resyncAfter}, nil
 }
 
 // sourceFetchError carries a stable reason + message for failStatus.

--- a/internal/controller/sopssecretmanifest_controller.go
+++ b/internal/controller/sopssecretmanifest_controller.go
@@ -154,7 +154,9 @@ func (r *SopsSecretManifestReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err := r.Status().Update(ctx, &sm); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	// Re-apply periodically: the target Secret is not watched, so this is the
+	// only thing that restores it if it is removed out of band (#83).
+	return ctrl.Result{RequeueAfter: resyncAfter}, nil
 }
 
 func (r *SopsSecretManifestReconciler) fetchManifestSource(ctx context.Context, sm *sopsv1alpha2.SopsSecretManifest) ([]byte, string, *sourceFetchError) {


### PR DESCRIPTION
Fixes #83

## The bug

A successful reconcile was terminal. Nothing watches the Secret a controller writes, and the success path returned a bare `ctrl.Result{}, nil` — so once an object had applied cleanly, the controller never looked at it again. Delete the Secret out of band and it stayed deleted, while the CR kept reporting `Applied=True`.

Observed on a live cluster: a `SopsSecretManifest`'s Secret deleted, still missing nine minutes later (well past its `GitRepository`'s 5m interval), all three conditions `True`. The consumer of that Secret sat at `Synced=False` for the whole window.

## Why not `Owns(&corev1.Secret{})`

`target.namespace` lets the Secret live in a different namespace than the CR, and ownerReferences are namespace-local. That is presumably why the operator already tracks ownership by label/annotation (`ManagedByLabel` / `OwnerAnnotation`, used by `deleteIfOwned`) rather than by owner reference. An `Owns()` watch would silently miss exactly the cross-namespace case.

## The change

All three secret-producing controllers requeue after a successful apply, via a new `resyncAfter = 5 * time.Minute` next to the existing `retryAfter`:

| controller | before | after |
|---|---|---|
| `SopsSecretManifest` | `ctrl.Result{}, nil` | `RequeueAfter: resyncAfter` |
| `SopsSecret` | `ctrl.Result{}, nil` | `RequeueAfter: resyncAfter` |
| `InlineSopsSecret` | `ctrl.Result{}, nil` | `RequeueAfter: resyncAfter` |

`SopsSecretManifest` and `SopsSecret` could previously recover *by accident* if their source object happened to be updated. `InlineSopsSecret` has no source watch at all — only `For(&InlineSopsSecret{})` — so it had no path back whatsoever.

## Two things I checked before assuming the requeue helps

Both would have made this a no-op:

- **No hash short-circuit.** `LastAppliedHash` is only ever written (`:150`), never compared, and there is no early return on an unchanged revision. Each reconcile genuinely re-fetches, re-decrypts and runs `CreateOrUpdate` — which *creates* a missing Secret rather than skipping it.
- **The fetch is cheap.** For git-backed sources it is `Registry.Read` against the clone the `GitRepository` controller already maintains, not a network round-trip per object per interval.

## Test

New spec in `gitsourced_happypath_test.go`: asserts the success result carries `RequeueAfter`, then deletes the target Secret and checks the next reconcile restores it with the right content.

Verified it actually tests the fix — with the change reverted:

```
• [FAILED] [2.322 seconds]
[FAIL] Git-sourced happy paths (envtest) SopsSecretManifest end-to-end
       [It] requeues after a successful apply and re-creates a deleted target Secret
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 39 Skipped
```

and with it in place, full `make test` (`-race`, envtest 1.35):

```
ok  internal/controller  24.847s  coverage: 65.6% of statements
```

all packages green.

## Possible follow-up

A `Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(...))` mapping back via `OwnerAnnotation` would react immediately instead of within an interval — the labels it needs are already written. This PR is the cheaper floor that covers all three controllers uniformly. Making the interval configurable (there is no duration flag in `cmd/main.go` today) would be a reasonable second step if 5m turns out to be wrong for anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo