### PR TITLE
ci(release): run on dagger-labda instead of dagger-labul

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,13 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
-    runs-on: dagger-labul
+    # dagger-labda rather than dagger-labul: the labul runner (`shuffle`) is a
+    # single machine, and while it was offline every release queued behind it
+    # indefinitely — two runs sat in `queued` for hours with no signal that
+    # anything was wrong. labda carries two runners under this label, so one
+    # being down no longer stalls releases. Nothing in this job is lab-specific:
+    # it needs git, dagger, docker and gh, and authenticates with GITHUB_TOKEN.
+    runs-on: dagger-labda
     environment: k8s
 
     steps:


### PR DESCRIPTION
`dagger-labul` resolves to a single machine (`shuffle`), and it is currently **offline**. While it has been down every release queued behind it indefinitely, with nothing surfacing the problem:

```
Release  queued  head=a0d7127  13:39
Release  queued  head=bf94d34  09:57
```

No failure, no timeout — just two runs sitting in `queued` for hours while the v0.8.5 image never appeared. That is how the resync fix (#84) ended up merged but unreleased.

## Change

`runs-on: dagger-labul` → `dagger-labda`, which carries **two** runners (`sthings-orga-runner-1/-2`, both online and idle), so one machine being down no longer stalls releases.

Nothing in this job is lab-specific — it needs git, dagger, docker and `gh`, and authenticates with `GITHUB_TOKEN` throughout. The other dagger-using workflow in this repo (`build-scan-image.yaml`) already runs on `ubuntu-latest`, so there is no hidden dependency on a stuttgart-things runner for the dagger calls themselves.

## After merging

This does **not** retroactively start the queued runs — they are pinned to the workflow definition at their own commit. To get a release out:

1. cancel the two stale queued runs
2. `workflow_dispatch` the Release workflow on `main`

Worth noting `main` has moved past #84 since: #73 and #71 (renovate) landed after it, so the release will carry those too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo