### PR TITLE
ci(release): serialise release runs with a concurrency group

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,18 @@ permissions:
   contents: write
   packages: write
 
+# Release fires on both workflow_run completion and workflow_dispatch, so
+# several runs can otherwise be in flight at once. When they overlap they race
+# on `git push --tags`: the loser dies with "cannot lock ref 'refs/tags/vX':
+# reference already exists" and never reaches its publish steps, leaving a tag
+# and a GitHub release with no image behind them. Seen on v0.8.5 (#86).
+#
+# cancel-in-progress is deliberately false: cancelling a run midway is exactly
+# how a release ends up half published. Queue instead.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     if: >-


### PR DESCRIPTION
Addresses the racing half of #86.

Release triggers on **both** `workflow_run` completion and `workflow_dispatch`, with no concurrency guard — so several runs can be in flight at once. Three overlapped while cutting v0.8.5 today and raced on the tag push:

```
! [remote rejected] v0.8.5 -> v0.8.5 (cannot lock ref 'refs/tags/v0.8.5': reference already exists)
error: failed to push some refs
```

The losing run aborted before its publish steps, leaving git tag `v0.8.5` and GitHub release `v0.8.5` with **no image behind them**. It only got completed because a concurrent run happened to still evaluate `new_release=true` — luck, not design: that gate is a tag delta computed within a single run, so a run starting *after* the tag exists skips every publish step and cannot repair the split state.

```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: false
```

**`cancel-in-progress: false` is the point.** Cancelling a run midway is exactly how a release ends up half published, so overlapping runs must queue rather than kill each other. `e2e.yaml` uses `true`, which is correct there and would be wrong here.

Verified the workflow still parses and the job is otherwise untouched (`runs-on: dagger-labda`, 10 steps).

## Not in this PR

The other half of #86 — every tag's `config/manager/kustomization.yaml` pinning the **previous** release's image (v0.8.5→v0.8.4, v0.8.4→v0.8.3, v0.8.3→v0.8.2, v0.8.2→v0.8.1) — needs a call on where the pin should live, so it stays in the issue. It is the more user-visible of the two: `kubectl apply -k …?ref=v0.8.5` installs the v0.8.4 image, which I hit bumping a cluster today.

A further follow-up worth considering: gate the publish steps on "does the image for $VERSION exist in the registry" instead of a tag delta, so a rerun can finish an interrupted release rather than skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo