### PR TITLE
ci(e2e): select the kind runners by label, not by machine name

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,12 +15,19 @@ concurrency:
 jobs:
   e2e:
     name: e2e (kind + cert-manager)
-    # Dedicated kind-only runner provisioned in #43. Two runners exist
-    # (kind-testing-runner-1, kind-testing-runner-2); pick one with a
-    # `runs-on` array fallback. With `concurrency: cancel-in-progress`
-    # set above only one job runs at a time anyway, so the second runner
-    # is hot-spare / room for a sibling project.
-    runs-on: [self-hosted, kind-testing-runner-1]
+    # Dedicated kind-only runners provisioned in #43. Select them by the
+    # shared `kind-testing-labda` label rather than by machine name, so
+    # either kind-testing-runner-1 or -2 can pick a job up.
+    #
+    # This used to say `[self-hosted, kind-testing-runner-1]`, described as
+    # an "array fallback". A `runs-on` array is an AND over labels, not a
+    # list of alternatives — it pinned every run to that one machine. The
+    # accompanying reasoning ("cancel-in-progress means only one job runs
+    # at a time anyway") does not hold either: the concurrency group above
+    # includes the PR number, so different PRs run concurrently by design.
+    # In practice four runs queued behind one busy machine while the other
+    # sat idle.
+    runs-on: [self-hosted, kind-testing-labda]
     timeout-minutes: 40
     permissions:
       contents: read


### PR DESCRIPTION
`runs-on: [self-hosted, kind-testing-runner-1]` was described in the comment as an *"array fallback"* across the two kind runners. It is not — a `runs-on` array is an **AND over labels**, so every e2e run was pinned to one specific machine.

The rest of that comment does not hold either. It argued the pin is harmless because `cancel-in-progress` means only one job runs at a time — but the concurrency group includes the PR number:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

so different PRs are *meant* to run concurrently. Observed today:

```
in_progress  head=56889dd  14:14   ← running 45+ min
queued       head=9024d34  14:23
queued       head=167f649  14:56
queued       head=bdbde00  14:56

kind-testing-runner-1: online busy=true
kind-testing-runner-2: online busy=false   ← idle the whole time
```

## Change

```diff
-    runs-on: [self-hosted, kind-testing-runner-1]
+    runs-on: [self-hosted, kind-testing-labda]
```

Both machines carry `kind-testing-labda`, so either can take a job while e2e still stays off the general-purpose runners:

```
kind-testing-runner-1: labels=self-hosted,Linux,X64,kind-testing-labda,kind-testing-runner-1
kind-testing-runner-2: labels=self-hosted,Linux,X64,kind-testing-labda,kind-testing-runner-2
```

**This PR's own e2e run is the test** — if it picks up on runner-2 while runner-1 is busy, the fix is demonstrated rather than argued.

## Related

Third instance of the same class today: #85 (release pinned to a single machine that was offline, queueing releases silently for hours) and #87 (no concurrency guard, so overlapping release runs raced on the tag push and half-published v0.8.5). A job tied to one host, with no signal when that host is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo