### PR TITLE
ci(release): let semantic-release write the image pin it just tagged

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,6 +4,13 @@
   "plugins": [
     ["@semantic-release/commit-analyzer", {"preset": "angular"}],
     ["@semantic-release/release-notes-generator", {"preset": "angular"}],
+    ["@semantic-release/exec", {
+      "prepareCmd": "git config user.email 'semantic-release-bot@stuttgart-things.com' && git config user.name 'semantic-release-bot' && sed -i 's|newTag: .*|newTag: v${nextRelease.version}|' config/manager/kustomization.yaml"
+    }],
+    ["@semantic-release/git", {
+      "assets": ["config/manager/kustomization.yaml"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]"
+    }],
     ["@semantic-release/github", {}]
   ]
 }


### PR DESCRIPTION
Closes #86.

## Problem

`config/manager/kustomization.yaml` pins the image the operator deploys, but nothing in the release pipeline ever updated it. So `main` permanently carried the **previous** release's tag:

| | |
|---|---|
| latest tag | `v0.8.5` |
| pin on `main` until yesterday | `v0.8.4` |

It only caught up because Renovate opened #88 — one release late, and only because Renovate happens to watch that image.

Consequence: anyone installing straight from the repo (`kubectl apply -k config/default`, or the ansible playbook in `stuttgart-things/ansible`) silently gets the release *before* the one they asked for. That playbook works around it today with an explicit `kustomize edit set image` step, which is exactly the kind of duplicated version knowledge this repo should own.

## Fix

Write the pin from the one place that already knows the version — semantic-release:

```json
["@semantic-release/exec", {
  "prepareCmd": "... && sed -i 's|newTag: .*|newTag: v${nextRelease.version}|' config/manager/kustomization.yaml"
}],
["@semantic-release/git", {
  "assets": ["config/manager/kustomization.yaml"],
  "message": "chore(release): ${nextRelease.version} [skip ci]"
}],
```

Ordering is the whole point: `exec` and `git` run in the **prepare** step, `@semantic-release/github` creates the tag in **publish**. The tag therefore points at a tree whose pin is already correct — no chicken-and-egg and no follow-up commit that would leave the tag itself wrong.

## Why this doesn't need a change in `stuttgart-things/dagger`

I checked before writing it:

- The dagger call is `semantic --src .`, so this repo's `.releaserc` is honoured — config-only change.
- `release/container.go:21-24` already installs `@semantic-release/exec` **and** `@semantic-release/git`. (The issue flagged this as an open risk; it isn't one.)
- `release/semantic.go` rewrites the `origin` remote with `x-access-token:$GITHUB_TOKEN`, the same mechanism that already pushes tags — so pushing a commit works over the same credential.

The issue also floated "just drop the pin" as an alternative. That one is not viable and I've noted so on the issue: `config/manager/manager.yaml:66` is `image: controller:latest`, so without the kustomize override you deploy the literal string `controller:latest`.

## Verified here

- `.releaserc` parses, plugin order is analyzer → notes → exec → git → github
- the `sed` matches exactly one line (`grep -c "newTag:"` → 1) and rewrites only that line

## Not verifiable before merge

The commit-back only happens in a real release run — semantic-release's dry-run does not execute `prepare`. **The first release after this merge is the actual test.** Two things to watch on that run:

1. the bot commit has to be allowed to land on `main` (branch protection);
2. `[skip ci]` keeps "CI - Build & Test" from re-running, and Release is triggered by `workflow_run` on that workflow — so there is no release loop.

Note this commit is `ci(...)`, which under the angular preset is not a releasable type. The fix goes live with the next `fix`/`feat` merged after it.
