### PR TITLE
ci: bump the dagger engine from 0.20.0 to 0.21.7

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build & push to ttl.sh
         uses: dagger/dagger-for-github@v8.4.1
         with:
-          version: "0.20.0"
+          version: "0.21.7"
           verb: call
           module: github.com/stuttgart-things/blueprints/kubernetes-microservice@v1.71.0
           args: >-
@@ -52,7 +52,7 @@ jobs:
       - name: Scan image
         uses: dagger/dagger-for-github@v8.4.1
         with:
-          version: "0.20.0"
+          version: "0.21.7"
           verb: call
           module: github.com/stuttgart-things/blueprints/kubernetes-microservice@v1.71.0
           args: >-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Semantic release
         uses: dagger/dagger-for-github@v8.4.1
         with:
-          version: "0.20.0"
+          version: "0.21.7"
           verb: call
           module: github.com/stuttgart-things/dagger/release@v0.86.0
           args: >-
@@ -116,7 +116,7 @@ jobs:
         if: steps.version-after.outputs.new_release == 'true'
         uses: dagger/dagger-for-github@v8.4.1
         with:
-          version: "0.20.0"
+          version: "0.21.7"
           verb: call
           module: github.com/stuttgart-things/dagger/kcl@v0.86.0
           args: >-


### PR DESCRIPTION
The post-merge container build on `main` ([run 29926203754](https://github.com/stuttgart-things/sops-secrets-operator/actions/runs/29926203754)) failed pulling the pinned engine:

```
docker pull registry.dagger.io/engine:v0.20.0
Error response from daemon: received unexpected HTTP status: 500 Internal Server Error
```

Bumps all **four** pins — two in `release.yaml`, two in `build-scan-image.yaml` — so release and image builds stay on one engine version. They share the self-hosted runners' docker daemon and image cache, so a split would mean pulling and storing two engines.

`v0.21.7` is the current stable dagger release (2026-06-17, `prerelease: false`).

The `stuttgart-things/dagger` modules stay pinned at `v0.86.0` — a newer engine runs older modules, not the other way round.

**What this PR can and cannot prove:** the `Build, Push & Scan` checks on this PR exercise both bumped steps in `build-scan-image.yaml`, so those are covered. The two in `release.yaml` only run post-merge on `main` — untested until the next release.