### PR TITLE
fix: register the conversion webhook only when a certificate was supplied

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -295,7 +295,33 @@ func main() {
 	// Register the conversion webhook for the v1alpha1 ↔ v1alpha2 hub.
 	// Without this the webhook Server starts but /convert is unhandled,
 	// so the apiserver gets connection refused when admitting v1alpha1 CRs.
-	mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(mgr.GetScheme(), conversion.NewRegistry()))
+	//
+	// ONLY WHEN A CERTIFICATE WAS SUPPLIED. Registering a handler makes
+	// controller-runtime start the webhook server, and the server needs a
+	// serving certificate; with none it returns
+	//
+	//   open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or
+	//   directory
+	//
+	// from mgr.Start(), which takes the WHOLE manager down -- every controller
+	// with it, in a CrashLoopBackOff that says nothing about conversion.
+	//
+	// config/default mounts a cert-manager certificate, so that path and the
+	// e2e job never see this. The kcl deploy profile deliberately ships no
+	// webhook and no cert (it exists precisely to avoid the cert-manager
+	// dependency), and its CRDs are installed with `conversion: None` -- so on
+	// that path the handler is not merely unusable, it is unnecessary. Skipping
+	// it is what the CRDs already say.
+	//
+	// Found on machinery-test1, 2026-09-01, and only after the RBAC gap in #105
+	// was closed: until then the manager blocked in WaitForCacheSync and never
+	// reached the webhook server at all. One defect was hiding the other.
+	if len(webhookCertPath) > 0 {
+		mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(mgr.GetScheme(), conversion.NewRegistry()))
+	} else {
+		setupLog.Info("No webhook certificate supplied, not registering the conversion webhook",
+			"note", "install the CRDs with conversion: None, or set --webhook-cert-path")
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up health check")


### PR DESCRIPTION
Einen Handler zu registrieren lässt controller-runtime den Webhook-Server **starten**, und der braucht ein Serving-Zertifikat. Ohne eines liefert `mgr.Start()`

```
open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory
```

und reißt damit den **gesamten** Manager mit — jeden Controller — in einen CrashLoopBackOff, dessen Fehlermeldung nichts mit Conversion zu tun zu haben scheint.

## Warum das nie aufgefallen ist

`config/default` mountet ein cert-manager-Zertifikat, also sehen der kustomize-Pfad und der e2e-Job (kind + cert-manager) das nie. Das kcl-Deploy-Profil liefert bewusst weder Webhook noch Zertifikat aus — es existiert ja gerade, um die cert-manager-Abhängigkeit zu vermeiden — und installiert seine CRDs mit `conversion: None`.

Auf diesem Pfad ist der Handler also nicht nur unbenutzbar, sondern **unnötig**. Ihn wegzulassen ist genau das, was die CRDs ohnehin sagen.

## Gefunden erst nach #105

Solange die `objectsources`-RBAC-Lücke bestand, blockierte der Manager in `WaitForCacheSync` und erreichte den Webhook-Server nie — er lief also leer, statt abzustürzen: Pod `1/1 Running`, jede CR angelegt, nichts reconciled.

Den ersten Defekt zu schließen hat den zweiten sichtbar gemacht, indem aus einem stillen No-op ein sichtbarer Crash-Loop wurde. Beide steckten im selben Artefakt, und keiner war für den e2e-Job erreichbar.

Verhalten unverändert überall dort, wo `--webhook-cert-path` gesetzt ist — also in jedem Deployment, das Conversion tatsächlich ausliefert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bo4t5KtdfkDWxLce8dLt7v